### PR TITLE
fix(studio): point outputFileTracingRoot to workspace root

### DIFF
--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
   // Fix monorepo tracing root - pointing to workspace root
-  outputFileTracingRoot: path.join(__dirname, "../../"),
+  outputFileTracingRoot: path.join(process.cwd(), "../../"),
   transpilePackages: ["@aix-core/storage", "aix-format"], 
   
   env: {


### PR DESCRIPTION
This PR points `outputFileTracingRoot` to the workspace root in `apps/studio/next.config.ts` to ensure Next.js trace files accurately capture dependencies across the monorepo. It replaces the incorrectly transpiled `__dirname` with `process.cwd()` which is resilient to ESM modules loading configurations.

---
*PR created automatically by Jules for task [9566169501374301155](https://jules.google.com/task/9566169501374301155) started by @Moeabdelaziz007*