### PR TITLE
🧪 Add tests for get_blackbox_logs invalid manifest paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "tailwindcss": "^4.2.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
-        "vitest": "^3.0.0"
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -20843,7 +20843,8 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.12.7",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "vitest": "^3.2.4"
       }
     },
     "packages/mcp-server/node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,6 @@
     "tailwindcss": "^4.2.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
-    "vitest": "^3.0.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -15,9 +15,10 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/node": "^20.12.7",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.12.7",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/mcp-server/tests/index.test.ts
+++ b/packages/mcp-server/tests/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import fs from "fs/promises";
+import path from "path";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("../../../core/abom-scanner.js", () => ({
+  scanAgent: vi.fn().mockReturnValue({ score: 100 })
+}));
+
+describe('MCP Server - get_blackbox_logs', () => {
+  let requestHandler: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    // We need to capture the request handler from the index.ts file
+    // To do this properly without starting the real server, we can mock Server.prototype.setRequestHandler
+    const mockSetRequestHandler = vi.fn((schema, handler) => {
+      if (schema === CallToolRequestSchema) {
+        requestHandler = handler;
+      }
+    });
+
+    vi.spyOn(Server.prototype, 'setRequestHandler').mockImplementation(mockSetRequestHandler);
+
+    // We must mock console.error to avoid spamming the test output
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Import the file to trigger setRequestHandler calls
+    await import('../src/index.js');
+  });
+
+  it('should return error when get_blackbox_logs receives invalid JSON', async () => {
+    // Mock fs.readFile to return invalid JSON
+    vi.mocked(fs.readFile).mockResolvedValue('{ "invalid": "json" ');
+
+    const request = {
+      params: {
+        name: "get_blackbox_logs",
+        arguments: {
+          manifestPath: "dummy.json"
+        }
+      }
+    };
+
+    const response = await requestHandler(request);
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('Expected');
+    expect(response.content[0].text).toContain('JSON');
+  });
+
+  it('should return error when get_blackbox_logs receives invalid YAML', async () => {
+    // Mock fs.readFile to return invalid YAML
+    vi.mocked(fs.readFile).mockResolvedValue('invalid: yaml: :\n');
+
+    const request = {
+      params: {
+        name: "get_blackbox_logs",
+        arguments: {
+          manifestPath: "dummy.yaml"
+        }
+      }
+    };
+
+    const response = await requestHandler(request);
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('bad indentation of a mapping entry');
+  });
+
+  it('should successfully parse valid JSON in get_blackbox_logs', async () => {
+    // Mock fs.readFile to return valid JSON
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({
+      meta: { id: "test-id", name: "Test Agent" },
+      black_box: { traces: [{ id: 1 }, { id: 2 }] }
+    }));
+
+    const request = {
+      params: {
+        name: "get_blackbox_logs",
+        arguments: {
+          manifestPath: "valid.json"
+        }
+      }
+    };
+
+    const response = await requestHandler(request);
+
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0].text).toContain('"agent_id": "test-id"');
+    expect(response.content[0].text).toContain('"total_logs": 2');
+  });
+});

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
🎯 **What:** The `get_blackbox_logs` tool in the MCP server previously lacked test coverage for error paths involving invalid manifest contents, such as malformed JSON or YAML, which caused parsing exceptions.
📊 **Coverage:** A test file `tests/index.test.ts` was added to `packages/mcp-server/`. It tests `get_blackbox_logs` with a valid JSON file (happy path), an invalid JSON file (parsing error), and an invalid YAML file (parsing error), making use of mock inputs and the Vitest framework.
✨ **Result:** Test coverage is expanded for the MCP server's error handling paths, ensuring it gracefully reports errors rather than crashing the process or behaving unpredictably.

---
*PR created automatically by Jules for task [14166784970175406485](https://jules.google.com/task/14166784970175406485) started by @Moeabdelaziz007*