### PR TITLE
fix(core): add errors array to AIXAgent class

### DIFF
--- a/core/parser.ts
+++ b/core/parser.ts
@@ -809,10 +809,12 @@ export class AIXParser {
 export class AIXAgent {
   readonly data: AIXDocument;
   readonly warnings: AIXValidationWarning[];
+  public errors: AIXValidationError[] = [];
 
   constructor(data: AIXDocument, warnings: AIXValidationWarning[] = []) {
     this.data = data;
     this.warnings = warnings;
+    this.errors = [];
   }
 
   get meta(): Meta                              { return this.data.meta; }


### PR DESCRIPTION
AIXAgent requires its own `errors` array to handle standalone validation calls properly outside the main parser context, such as with `validateLiveVoice()`. This fix adds `public errors: AIXValidationError[] = [];` to the AIXAgent class structure and initializes `this.errors = [];` in its constructor within `core/parser.ts`. Tests confirmed backward compatibility and corrected standalone functionality.

---
*PR created automatically by Jules for task [15839039770075513938](https://jules.google.com/task/15839039770075513938) started by @Moeabdelaziz007*