### PR TITLE
🧪 [Test Improvement] Add circular reference test case for canonicalize

### DIFF
--- a/tests/canonicalize.test.js
+++ b/tests/canonicalize.test.js
@@ -14,3 +14,9 @@ test('canonicalization is deterministic with reordered keys', () => {
 test('canonicalization rejects unsupported types', () => {
   assert.throws(() => canonicalizeForSigning({ meta: { fn: () => {} } }), /CANON_UNSUPPORTED_TYPE/);
 });
+
+test('canonicalization rejects circular references', () => {
+  const obj = { a: 1 };
+  obj.self = obj;
+  assert.throws(() => canonicalizeForSigning(obj), /CANON_CIRCULAR_REFERENCE/);
+});


### PR DESCRIPTION
🎯 **What:** Adds a missing test case to ensure the canonicalize function correctly identifies and rejects objects with circular references.
📊 **Coverage:** Validates that `CANON_CIRCULAR_REFERENCE` is thrown when an object references itself.
✨ **Result:** Increased reliability and testing coverage for the canonicalize feature, verifying correct error handling.

---
*PR created automatically by Jules for task [2634668945219187813](https://jules.google.com/task/2634668945219187813) started by @Moeabdelaziz007*