### PR TITLE
fix(core): remove dangling plugin exports breaking parser import

### DIFF
--- a/core/parser.js
+++ b/core/parser.js
@@ -520,7 +520,11 @@ export class AIXAgent {
 }
 
 // ─── Plugin System Exports ────────────────────────────────────────────────────
-// Export plugin system for external use
-export { defaultRegistry, PluginRegistry };
-export { ValidationPlugin } from './validation-plugins.js';
-export * from './plugins/index.js';
+// The plugin system (`defaultRegistry`, `PluginRegistry`, `ValidationPlugin`,
+// and `./plugins/*`) was removed in an earlier refactor but the re-exports
+// were left behind. They referenced undefined identifiers and missing files,
+// which caused `import { AIXParser } from '../core/parser.js'` to fail at
+// module-link time with:
+//   SyntaxError: Export 'PluginRegistry' is not defined in module
+// The exports below are intentionally omitted until the plugin system is
+// re-introduced. If/when it is, re-export it from its concrete module here.


### PR DESCRIPTION
The trailing block in `core/parser.js` re-exported `defaultRegistry`, `PluginRegistry`, `ValidationPlugin`, and `./plugins/index` without any matching imports or files. After the plugin system was removed in an earlier refactor these re-exports were left behind, so any external consumer of the parser (`import { AIXParser } from 'aix-format/core/parser.js'`) was failing at module-link time with `SyntaxError: Export 'PluginRegistry' is not defined in module`. That blocks the planned IQRA runtime validator integration and any other downstream consumer.

How it works:
- Drops the three dangling re-export lines at the end of `core/parser.js`.
- Leaves a comment marking the seam so the plugin system can be re-exported from a real module if/when it is reintroduced.
- No other behavioural change. The `AIXParser` and `AIXAgent` named exports remain identical.

Reproducer before this PR:

```
$ node --input-type=module -e "import('./core/parser.js')"
SyntaxError: Export 'PluginRegistry' is not defined in module
```

After this PR the module links cleanly and existing parser tests run against the real exports. Two test files (`tests/validation-plugins.test.js`, `tests/plugin-loader.test.js`) and `examples/custom-validator-plugin.js` still reference the missing `core/validation-plugins.js` and `core/plugins/index.js` files; they were already broken on `main` for the same reason and are intentionally left alone here to keep this PR's scope to the single concern of unblocking the parser import. They should be either removed or restored alongside a real plugin-system reintroduction in a follow-up PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->