### PR TITLE
fix(rules): rename test: to check: in 5 broken rule files

### DIFF
--- a/core/rules/economics-rules.js
+++ b/core/rules/economics-rules.js
@@ -7,7 +7,7 @@ export const economicsRules = [
   // Pi Smart Contract
   {
     name: 'economics.pi_smart_contract.address.required',
-    test: (data) => {
+    check: (data) => {
       const psc = data.economics?.pi_smart_contract;
       return !psc || !!psc.address;
     },
@@ -18,7 +18,7 @@ export const economicsRules = [
   
   {
     name: 'economics.pi_smart_contract.network.valid',
-    test: (data) => {
+    check: (data) => {
       const network = data.economics?.pi_smart_contract?.network;
       if (!network) return true;
       return ['pi-mainnet', 'pi-testnet', 'sandbox'].includes(network);
@@ -31,7 +31,7 @@ export const economicsRules = [
   // Wallets
   {
     name: 'economics.wallets.type',
-    test: (data) => {
+    check: (data) => {
       const wallets = data.economics?.wallets;
       return !wallets || Array.isArray(wallets);
     },
@@ -42,7 +42,7 @@ export const economicsRules = [
   
   {
     name: 'economics.wallets.required_fields',
-    test: (data) => {
+    check: (data) => {
       const wallets = data.economics?.wallets;
       if (!wallets || !Array.isArray(wallets)) return true;
       return wallets.every(w => w.chain && w.address);
@@ -54,7 +54,7 @@ export const economicsRules = [
   // Payment Gateways
   {
     name: 'economics.payment_gateways.stripe_acp.merchant_id',
-    test: (data) => {
+    check: (data) => {
       const stripe = data.economics?.payment_gateways?.stripe_acp;
       return !stripe || !stripe.enabled || !!stripe.merchant_id;
     },
@@ -66,7 +66,7 @@ export const economicsRules = [
   
   {
     name: 'economics.payment_gateways.paypal_ap2.mandate_id',
-    test: (data) => {
+    check: (data) => {
       const paypal = data.economics?.payment_gateways?.paypal_ap2;
       return !paypal || !paypal.enabled || !!paypal.mandate_id;
     },
@@ -79,7 +79,7 @@ export const economicsRules = [
   // Delegation
   {
     name: 'economics.delegation.max_depth',
-    test: (data) => {
+    check: (data) => {
       const del = data.economics?.delegation;
       return !del || !del.allow_recursive || del.max_depth <= 5;
     },
@@ -91,7 +91,7 @@ export const economicsRules = [
   // Treasury
   {
     name: 'economics.treasury.flash_loan_arbitrage',
-    test: (data) => {
+    check: (data) => {
       const tre = data.economics?.treasury;
       if (!tre || !tre.flash_loan_arbitrage_enabled) return true;
       return !!data.security?.guardian_logic?.mempool_monitor;

--- a/core/rules/identity-rules.js
+++ b/core/rules/identity-rules.js
@@ -8,7 +8,7 @@ import { isValidID, isValidISO8601 } from '../validation-utils.js';
 export const identityRules = [
   {
     name: 'identity_layer.id.required',
-    test: (data) => !!data.identity_layer?.id,
+    check: (data) => !!data.identity_layer?.id,
     message: "Required field 'identity_layer.id' is missing",
     section: 'identity_layer',
     field: 'id'
@@ -16,7 +16,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.authority.required',
-    test: (data) => !!data.identity_layer?.authority,
+    check: (data) => !!data.identity_layer?.authority,
     message: "Required field 'identity_layer.authority' is missing",
     section: 'identity_layer',
     field: 'authority'
@@ -24,7 +24,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.issuedAt.required',
-    test: (data) => !!data.identity_layer?.issuedAt,
+    check: (data) => !!data.identity_layer?.issuedAt,
     message: "Required field 'identity_layer.issuedAt' is missing",
     section: 'identity_layer',
     field: 'issuedAt'
@@ -32,7 +32,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.id.format',
-    test: (data) => {
+    check: (data) => {
       const id = data.identity_layer?.id;
       return !id || isValidID(id);
     },
@@ -43,7 +43,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.authority.axiom',
-    test: (data) => {
+    check: (data) => {
       const id = data.identity_layer?.id;
       const authority = data.identity_layer?.authority;
       if (!id || !authority) return true;
@@ -59,7 +59,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.authority.web',
-    test: (data) => {
+    check: (data) => {
       const id = data.identity_layer?.id;
       const authority = data.identity_layer?.authority;
       if (!id || !authority) return true;
@@ -82,7 +82,7 @@ export const identityRules = [
   
   {
     name: 'identity_layer.issuedAt.format',
-    test: (data) => {
+    check: (data) => {
       const issuedAt = data.identity_layer?.issuedAt;
       return !issuedAt || isValidISO8601(issuedAt);
     },

--- a/core/rules/pi-network-rules.js
+++ b/core/rules/pi-network-rules.js
@@ -8,7 +8,7 @@ import { isValidSemver } from '../validation-utils.js';
 export const piNetworkRules = [
   {
     name: 'pi_network.app_id.required',
-    test: (data) => {
+    check: (data) => {
       const pi = data.pi_network;
       return !pi || !!pi.app_id;
     },
@@ -19,7 +19,7 @@ export const piNetworkRules = [
   
   {
     name: 'pi_network.environment.required',
-    test: (data) => {
+    check: (data) => {
       const pi = data.pi_network;
       return !pi || !!pi.environment;
     },
@@ -30,7 +30,7 @@ export const piNetworkRules = [
   
   {
     name: 'pi_network.environment.valid',
-    test: (data) => {
+    check: (data) => {
       const env = data.pi_network?.environment;
       if (!env) return true;
       return ['sandbox', 'production'].includes(env);
@@ -42,7 +42,7 @@ export const piNetworkRules = [
   
   {
     name: 'pi_network.sdk_version.format',
-    test: (data) => {
+    check: (data) => {
       const version = data.pi_network?.sdk_version;
       return !version || isValidSemver(version);
     },

--- a/core/rules/pricing-rules.js
+++ b/core/rules/pricing-rules.js
@@ -6,7 +6,7 @@
 export const pricingRules = [
   {
     name: 'pricing.currency.valid',
-    test: (data) => {
+    check: (data) => {
       const currency = data.pricing?.currency || data.economics?.pricing?.currency;
       if (!currency) return true;
       const valid = ['USD', 'EUR', 'BTC', 'ETH', 'PI'];
@@ -24,7 +24,7 @@ export const pricingRules = [
   
   {
     name: 'pricing.model.valid',
-    test: (data) => {
+    check: (data) => {
       const model = data.pricing?.model || data.economics?.pricing?.model;
       if (!model) return true;
       const valid = ['pay_per_call', 'subscription', 'freemium', 'tiered'];
@@ -40,7 +40,7 @@ export const pricingRules = [
   
   {
     name: 'pricing.cost_per_call.amount',
-    test: (data) => {
+    check: (data) => {
       const amount = data.pricing?.cost_per_call?.amount || data.economics?.pricing?.cost_per_call?.amount;
       return amount === undefined || (typeof amount === 'number' && amount >= 0);
     },
@@ -51,7 +51,7 @@ export const pricingRules = [
   
   {
     name: 'pricing.subscription.monthly_fee.amount',
-    test: (data) => {
+    check: (data) => {
       const amount = data.pricing?.subscription?.monthly_fee?.amount || 
                      data.economics?.pricing?.subscription?.monthly_fee?.amount;
       return amount === undefined || (typeof amount === 'number' && amount >= 0);
@@ -63,7 +63,7 @@ export const pricingRules = [
   
   {
     name: 'pricing.subscription.included_calls',
-    test: (data) => {
+    check: (data) => {
       const calls = data.pricing?.subscription?.included_calls || 
                     data.economics?.pricing?.subscription?.included_calls;
       return calls === undefined || (Number.isInteger(calls) && calls >= 0);

--- a/core/rules/requirements-rules.js
+++ b/core/rules/requirements-rules.js
@@ -6,7 +6,7 @@
 export const requirementsRules = [
   {
     name: 'requirements.hardware.cpu_cores',
-    test: (data) => {
+    check: (data) => {
       const cores = data.requirements?.hardware?.cpu_cores;
       return cores === undefined || (Number.isInteger(cores) && cores >= 1);
     },
@@ -17,7 +17,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.hardware.memory_mb',
-    test: (data) => {
+    check: (data) => {
       const mem = data.requirements?.hardware?.memory_mb;
       return mem === undefined || (Number.isInteger(mem) && mem >= 1);
     },
@@ -28,7 +28,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.hardware.storage_mb',
-    test: (data) => {
+    check: (data) => {
       const storage = data.requirements?.hardware?.storage_mb;
       return storage === undefined || (Number.isInteger(storage) && storage >= 1);
     },
@@ -39,7 +39,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.hardware.gpu_memory_mb',
-    test: (data) => {
+    check: (data) => {
       const gpu = data.requirements?.hardware?.gpu_memory_mb;
       return gpu === undefined || (Number.isInteger(gpu) && gpu >= 1);
     },
@@ -50,7 +50,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.network.bandwidth_mbps',
-    test: (data) => {
+    check: (data) => {
       const bw = data.requirements?.network?.bandwidth_mbps;
       return bw === undefined || (typeof bw === 'number' && bw >= 0);
     },
@@ -61,7 +61,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.vla.adapter.required',
-    test: (data) => {
+    check: (data) => {
       const vla = data.requirements?.vla;
       return !vla || !!vla.adapter;
     },
@@ -72,7 +72,7 @@ export const requirementsRules = [
   
   {
     name: 'requirements.vla.adapter.valid',
-    test: (data) => {
+    check: (data) => {
       const adapter = data.requirements?.vla?.adapter;
       if (!adapter) return true;
       const allowed = ['openpi', 'π0.7', 'generic'];


### PR DESCRIPTION
The validation engine's `register()` in `core/validation-engine.js` requires every rule to expose `rule.name` and `rule.check`, and the parser registers all rules at module load with:

```js
import { allRules } from './rules/index.js';
allRules.forEach(register);
```

Five rule modules used the property name `test:` instead of `check:`, so the very first one of them in the load order (`requirementsRules`) made the whole import throw at module link with `Error: Rule must have name and check function at register (core/validation-engine.js:17:11)`. Every downstream consumer of `AIXParser` was broken by this, and the **Security Signature Gate** workflow has been failing on every push/PR because its parser smoke tests can't even load the module ([example run](https://github.com/Moeabdelaziz007/aix-format/actions/runs/25778824593)).

Affected files (31 occurrences total, all mechanical renames, arrow signature and return contract unchanged):

| File | Rules |
|---|---|
| `core/rules/economics-rules.js` | 8 |
| `core/rules/identity-rules.js` | 7 |
| `core/rules/pi-network-rules.js` | 4 |
| `core/rules/pricing-rules.js` | 5 |
| `core/rules/requirements-rules.js` | 7 |

The other 8 rule files (meta, persona, security, skills, apis, mcp, memory, abom) already use `check:` and are untouched. Verified end-to-end in a Node REPL after the rename:

```
✅ Registered 70 rules without error
✅ validate() ran with minimal manifest
```

No behavioural change beyond unblocking module load. This is the second in a short series of small CI-unblock PRs (after #129 for the studio install flag). Two known follow-ups remain before main is green: TypeScript syntax errors in `apps/studio/src/app/space/page.tsx` and `apps/studio/src/components/studio/VoiceWizard.tsx`, and the 22 `Math.random()` violations the Pattern Watcher flags as `RULE 2` failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal validation system updated across multiple rule modules to use standardized function property naming. No user-facing functionality changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moeabdelaziz007/aix-format/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->