### PR TITLE
chore(workspace): list Node packages explicitly, exclude Go/Rust/types-only dirs

### DIFF
--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -26,7 +26,8 @@
       "@/design-system/*": ["./src/design-system/*"],
       "@/constants/*": ["./src/constants/*"],
       "@aix-core": ["../../packages/aix-core/src/index.ts"],
-      "@aix-core/*": ["../../packages/aix-core/src/*"]
+      "@aix-core/*": ["../../packages/aix-core/src/*"],
+      "@aix-types": ["../../packages/aix-types/index.d.ts"]
     },
     "target": "ES2017",
     "forceConsistentCasingInFileNames": true

--- a/package.json
+++ b/package.json
@@ -102,7 +102,12 @@
   },
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/aix-core",
+    "packages/aix-rust-core",
+    "packages/aix-zkkyc",
+    "packages/mcp-gateway",
+    "packages/mcp-server",
+    "packages/pi-kyc"
   ],
   "dependencies": {
     "@ai-sdk/google": "^1.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,18 @@
 packages:
   - 'apps/*'
-  - 'packages/*'
+  # List packages explicitly instead of 'packages/*' because three
+  # entries in packages/ are not Node packages and lack package.json:
+  #   - packages/aix-agency  (Go module, has go.mod)
+  #   - packages/aix-dna     (Rust crate, has Cargo.toml)
+  #   - packages/aix-types   (TypeScript .d.ts only, resolved via tsconfig path alias)
+  # Globbing them in caused 'ENOENT package.json' warnings on every
+  # `pnpm install` and made the workspace view of the repo wrong.
+  - 'packages/aix-core'
+  - 'packages/aix-rust-core'
+  - 'packages/aix-zkkyc'
+  - 'packages/mcp-gateway'
+  - 'packages/mcp-server'
+  - 'packages/pi-kyc'
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Both `pnpm-workspace.yaml` and `package.json` `workspaces` globbed `packages/*`, but three entries in `packages/` are not Node packages and have no `package.json`:

| Directory | What it actually is |
|---|---|
| `packages/aix-agency` | Go module — `go.mod`, `go.sum`, `cmd/`, `pkg/` |
| `packages/aix-dna` | Rust crate — `Cargo.toml`, `src/lib.rs`, `src/main.rs` |
| `packages/aix-types` | A single TypeScript `index.d.ts` (no runtime code) |

Including them under `packages/*` made pnpm log `ENOENT package.json` warnings on every install and broke any tool that walks the workspace tree (filtering, dependency graphs, codemods, our own `consolidate.ts`). Studio's TypeScript also couldn't actually resolve `import { ... } from '@aix-types'` because there was no `@aix-types` path alias in `apps/studio/tsconfig.json` — the imports were latent broken and only hidden because upstream JSX errors in #131 short-circuited the typecheck.

This PR:
- Replaces `packages/*` with the six real Node packages in both `pnpm-workspace.yaml` and `package.json` `workspaces`: `aix-core`, `aix-rust-core`, `aix-zkkyc`, `mcp-gateway`, `mcp-server`, `pi-kyc`. Each was verified to carry a valid `package.json`.
- Adds a comment in `pnpm-workspace.yaml` explaining why `aix-agency`, `aix-dna`, and `aix-types` are deliberately excluded.
- Adds an `@aix-types` `tsconfig` path alias in `apps/studio/tsconfig.json` pointing at `packages/aix-types/index.d.ts` so the existing studio imports compile. The alias alone is sufficient because `aix-types` exports only types and the import is fully erased at compile time — no runtime resolution is needed.

`aix-agency` keeps its Go toolchain. `aix-dna` keeps its Cargo build. `aix-types` stays the single-file `.d.ts` it always was. No source code or schema changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->