### PR TITLE
feat(schema): add v0.369.0 optional fields — aix_version, safety_score, zk_proof, pi_uid_anchor, x402_endpoint (PR #A of 5)

### DIFF
--- a/schemas/aix.schema.json
+++ b/schemas/aix.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://axiomid.app/schemas/aix.schema.json",
-  "$comment": "AIX Format v0.369.0 — Unified Canonical Bundled Schema. Supersedes aix-v1.schema.json, axiom-aix.schema.json, aix-enhanced.schema.json. © 2026 Mohamed Abdelaziz / AMRIKYY AI Solutions",
+  "$comment": "AIX Format v0.369.0 — Unified Canonical Bundled Schema. Supersedes aix-v1.schema.json, axiom-aix.schema.json, aix-enhanced.schema.json. © 2026 Mohamed Abdelaziz / AMRIKYY AI Solutions. v0.369.0+ adds optional fields aix_version, skills[].safety_score, identity_layer.zk_proof, identity_layer.pi_uid_anchor, economics.wallets[].x402_endpoint — all backward compatible.",
   "title": "AIX Format",
   "description": "Unified JSON Schema for AIX (Artificial Intelligence eXchange) v0.369.0 — Sovereign Protocol. The Digital DNA of autonomous AI agents. Created by Mohamed Abdelaziz - AMRIKYY AI Solutions 2026",
   "type": "object",
@@ -74,6 +74,35 @@
           "enum": ["JCS", "RFC8785"],
           "default": "JCS",
           "description": "JSON canonicalization scheme used before signing"
+        }
+      }
+    },
+    "ZKProof": {
+      "type": "object",
+      "description": "Zero-knowledge proof structure (Groth16). Mirrors the ZKProof interface in packages/aix-zkkyc/src/ProofVerifier.ts so on-chain proofs round-trip through the manifest without re-encoding.",
+      "required": ["proof", "publicSignals", "nullifier"],
+      "additionalProperties": false,
+      "properties": {
+        "proof": {
+          "description": "Groth16 proof object as produced by snarkjs. Free-form because the snarkjs shape (a, b, c, protocol, curve) is not stable across versions.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "publicSignals": {
+          "type": "array",
+          "description": "Public inputs to the proof — decimal-encoded field elements as strings",
+          "items": { "type": "string" }
+        },
+        "nullifier": {
+          "type": "string",
+          "description": "Unique proof identifier used by NullifierRegistry to prevent replay attacks. Recommended: SHA-256 hex.",
+          "minLength": 32
+        },
+        "timestamp": { "$ref": "#/$defs/ISODateTime" },
+        "circuit": {
+          "type": "string",
+          "description": "Identifier of the circuit that produced this proof (e.g. pkyc-v1, age-over-18-v2). Recommended for verifier dispatch.",
+          "examples": ["pkyc-v1"]
         }
       }
     },
@@ -153,6 +182,12 @@
   },
 
   "properties": {
+    "aix_version": {
+      "$ref": "#/$defs/SemVer",
+      "description": "Optional top-level shorthand for the AIX schema version this manifest targets (e.g. \"0.369.0\"). When omitted, consumers should fall back to meta.format_version, then to the schema URL parsed from $id, then to '0.369.0'. Schema registry: https://axiomid.app/schemas/aix.schema.json",
+      "examples": ["0.369.0", "1.0.0"]
+    },
+
     "meta": {
       "type": "object",
       "description": "Agent metadata and identification",
@@ -183,7 +218,11 @@
         "language": { "type": "string", "pattern": "^[a-z]{2}$", "examples": ["en", "ar"] },
         "framework": { "type": "string", "examples": ["openai", "anthropic", "gemini"] },
         "runtime_version": { "type": "string" },
-        "format_version": { "type": "string", "description": "AIX format version (e.g. 1.3)", "examples": ["1.3"] },
+        "format_version": {
+          "type": "string",
+          "description": "AIX format version this manifest targets. Co-exists with the top-level `aix_version` shorthand; when both are present, consumers SHOULD treat them as equal (a validator MAY warn on disagreement). Free-form for legacy reasons — prefer SemVer.",
+          "examples": ["1.3", "0.369.0"]
+        },
         "lineage": {
           "type": "array",
           "description": "Agent genealogy and heritage tracking",
@@ -330,7 +369,17 @@
         "issuedAt": { "$ref": "#/$defs/ISODateTime" },
         "expiresAt": { "$ref": "#/$defs/ISODateTime" },
         "publicKey": { "$ref": "#/$defs/PublicKey" },
-        "signature": { "$ref": "#/$defs/Signature" }
+        "signature": { "$ref": "#/$defs/Signature" },
+        "pi_uid_anchor": {
+          "type": "string",
+          "description": "Optional Pi Network user-ID anchor. SHA-256 hex of the verified Pi UID (32 bytes / 64 hex chars). Binds this DID to a verified Pi user without revealing the UID itself. Produced by packages/pi-kyc hashPiUid(). When present, resolvers SHOULD verify the value matches the KYC proof returned by Pi.",
+          "pattern": "^[0-9a-f]{64}$",
+          "examples": ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+        },
+        "zk_proof": {
+          "$ref": "#/$defs/ZKProof",
+          "description": "Optional zero-knowledge KYC proof attesting to identity properties (tier, jurisdiction, age, etc.) without revealing the underlying data. Verified by packages/aix-zkkyc ProofVerifier. Replay protection is handled at verification time via the nullifier registry; presence of this field does not by itself confer KYC status."
+        }
       }
     },
 
@@ -391,7 +440,7 @@
 
     "skills": {
       "type": "array",
-      "description": "Agent capabilities",
+      "description": "Agent capabilities — the MCP-flavoured tool surface the agent exposes. Each entry is one tool / capability.",
       "items": {
         "type": "object",
         "required": ["name", "description"],
@@ -404,7 +453,14 @@
           "triggers": { "type": "array", "items": { "type": "string" } },
           "examples": { "type": "array", "items": { "type": "string" } },
           "priority": { "type": "integer", "minimum": 1, "maximum": 10 },
-          "timeout": { "type": "integer", "minimum": 1 }
+          "timeout": { "type": "integer", "minimum": 1 },
+          "safety_score": {
+            "type": "number",
+            "description": "Per-tool safety score on a 0-10 scale. 10 = fully sandboxed read-only operation; 0 = arbitrary code execution / unbounded side effects. Consumers can use this to gate dispatch (e.g. require safety_score >= 7 for autonomous runs). Optional — defaults to 5 (unknown / standard) when omitted.",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          }
         }
       }
     },
@@ -564,7 +620,13 @@
               "chain": { "type": "string", "enum": ["base", "solana", "arbitrum", "pi-mainnet"] },
               "address": { "type": "string" },
               "provider": { "type": "string", "enum": ["coinbase-agentkit", "stripe-agent-wallet", "generic"] },
-              "tee_secured": { "type": "boolean", "default": false }
+              "tee_secured": { "type": "boolean", "default": false },
+              "x402_endpoint": {
+                "type": "string",
+                "format": "uri",
+                "description": "Optional HTTP 402 Payment Required endpoint URL this wallet exposes for pay-per-call settlements (RFC-style x402 flow, see economics.payment_gateways.x402 for the top-level enable flag). Clients hit this URL, receive a 402 with payment instructions referencing the wallet address, settle, then retry the original request.",
+                "examples": ["https://pay.example.com/x402/agent-001"]
+              }
             }
           }
         },

--- a/tests/fixtures/schema/README.md
+++ b/tests/fixtures/schema/README.md
@@ -1,0 +1,26 @@
+# Schema fixtures
+
+Each `.aix.json` file in this directory is a hand-crafted manifest that
+exercises a specific schema surface for regression-detection purposes.
+
+| Fixture | Purpose |
+|---|---|
+| `v0.369.0-optional-fields.aix.json` | Exercises every optional field added in the v0.369.0 schema bump: top-level `aix_version`; `skills[].safety_score`; `identity_layer.zk_proof` (Groth16 shape, mirrors `packages/aix-zkkyc/src/ProofVerifier.ts` `ZKProof`); `identity_layer.pi_uid_anchor` (SHA-256 hex of a Pi UID); and `economics.wallets[].x402_endpoint` (HTTP 402 settlement URL). Must validate against `schemas/aix.schema.json` with zero errors. |
+
+To re-validate manually after schema changes:
+
+```bash
+pnpm install
+node -e '
+const Ajv2020 = require("./node_modules/.pnpm/ajv@8.20.0/node_modules/ajv/dist/2020.js").default;
+const addFormats = require("./node_modules/.pnpm/ajv-formats@3.0.1_ajv@8.20.0/node_modules/ajv-formats/dist/index.js").default;
+const fs = require("fs");
+const ajv = new Ajv2020({strict:false, allErrors:true});
+addFormats(ajv);
+const validate = ajv.compile(JSON.parse(fs.readFileSync("schemas/aix.schema.json","utf8")));
+for (const f of fs.readdirSync("tests/fixtures/schema").filter(x=>x.endsWith(".aix.json"))) {
+  const ok = validate(JSON.parse(fs.readFileSync("tests/fixtures/schema/"+f,"utf8")));
+  console.log((ok?"PASS":"FAIL")+": "+f);
+  if (!ok) console.log(JSON.stringify(validate.errors,null,2));
+}'
+```

--- a/tests/fixtures/schema/v0.369.0-optional-fields.aix.json
+++ b/tests/fixtures/schema/v0.369.0-optional-fields.aix.json
@@ -1,0 +1,69 @@
+{
+  "aix_version": "0.369.0",
+  "meta": {
+    "description": "Fixture exercising every optional field introduced in AIX v0.369.0 schema bump: aix_version, skills[].safety_score, identity_layer.zk_proof, identity_layer.pi_uid_anchor, economics.wallets[].x402_endpoint. Must validate against schemas/aix.schema.json with zero errors.",
+    "version": "1.0.0",
+    "id": "did:axiom:axiomid.app:v0369-optional-fields-fixture",
+    "name": "v0.369.0 Optional Fields Fixture",
+    "created": "2026-05-13T00:00:00Z",
+    "author": "Mohamed Abdelaziz",
+    "format_version": "0.369.0"
+  },
+  "persona": {
+    "role": "Schema fixture",
+    "instructions": "This manifest exists only to exercise the optional fields added in v0.369.0."
+  },
+  "security": {
+    "checksum": {
+      "algorithm": "sha256",
+      "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "identity_layer": {
+    "id": "did:axiom:axiomid.app:v0369-optional-fields-fixture",
+    "authority": "axiomid.app",
+    "issuedAt": "2026-05-13T00:00:00Z",
+    "pi_uid_anchor": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+    "zk_proof": {
+      "proof": {
+        "pi_a": ["1", "2", "1"],
+        "pi_b": [["3", "4"], ["5", "6"], ["1", "0"]],
+        "pi_c": ["7", "8", "1"],
+        "protocol": "groth16",
+        "curve": "bn128"
+      },
+      "publicSignals": ["1"],
+      "nullifier": "f7c3bc1d808e04732adf679965ccc34ca7ae3441",
+      "timestamp": "2026-05-13T00:00:00Z",
+      "circuit": "pkyc-v1"
+    }
+  },
+  "skills": [
+    {
+      "name": "read_only_index",
+      "description": "Read-only vector index lookup, fully sandboxed.",
+      "safety_score": 10
+    },
+    {
+      "name": "send_email",
+      "description": "Send transactional email via SMTP.",
+      "safety_score": 4
+    },
+    {
+      "name": "execute_shell",
+      "description": "Run arbitrary shell commands. Never enabled in autonomous runs.",
+      "enabled": false,
+      "safety_score": 0
+    }
+  ],
+  "economics": {
+    "wallets": [
+      {
+        "chain": "base",
+        "address": "0x1234567890abcdef1234567890abcdef12345678",
+        "provider": "coinbase-agentkit",
+        "x402_endpoint": "https://pay.example.com/x402/agent-v0369"
+      }
+    ]
+  }
+}

--- a/types/parser.d.ts
+++ b/types/parser.d.ts
@@ -39,6 +39,10 @@ export type AxiomDID = string;
  */
 export interface AIXFormat {
   /**
+   * Optional top-level shorthand for the AIX schema version this manifest targets (e.g. "0.369.0"). When omitted, consumers should fall back to meta.format_version, then to the schema URL parsed from $id, then to '0.369.0'. Schema registry: https://axiomid.app/schemas/aix.schema.json
+   */
+  aix_version?: string;
+  /**
    * Agent metadata and identification
    */
   meta: {
@@ -79,7 +83,7 @@ export interface AIXFormat {
     framework?: string;
     runtime_version?: string;
     /**
-     * AIX format version (e.g. 1.3)
+     * AIX format version this manifest targets. Co-exists with the top-level `aix_version` shorthand; when both are present, consumers SHOULD treat them as equal (a validator MAY warn on disagreement). Free-form for legacy reasons — prefer SemVer.
      */
     format_version?: string;
     /**
@@ -198,6 +202,11 @@ export interface AIXFormat {
     expiresAt?: ISODateTime;
     publicKey?: PublicKey;
     signature?: Signature;
+    /**
+     * Optional Pi Network user-ID anchor. SHA-256 hex of the verified Pi UID (32 bytes / 64 hex chars). Binds this DID to a verified Pi user without revealing the UID itself. Produced by packages/pi-kyc hashPiUid(). When present, resolvers SHOULD verify the value matches the KYC proof returned by Pi.
+     */
+    pi_uid_anchor?: string;
+    zk_proof?: ZKProof;
   };
   trustchain?: {
     entries: {
@@ -237,7 +246,7 @@ export interface AIXFormat {
     [k: string]: unknown | undefined;
   };
   /**
-   * Agent capabilities
+   * Agent capabilities — the MCP-flavoured tool surface the agent exposes. Each entry is one tool / capability.
    */
   skills?: {
     name: string;
@@ -250,6 +259,10 @@ export interface AIXFormat {
     examples?: string[];
     priority?: number;
     timeout?: number;
+    /**
+     * Per-tool safety score on a 0-10 scale. 10 = fully sandboxed read-only operation; 0 = arbitrary code execution / unbounded side effects. Consumers can use this to gate dispatch (e.g. require safety_score >= 7 for autonomous runs). Optional — defaults to 5 (unknown / standard) when omitted.
+     */
+    safety_score?: number;
   }[];
   /**
    * API integrations
@@ -345,6 +358,10 @@ export interface AIXFormat {
       address: string;
       provider?: "coinbase-agentkit" | "stripe-agent-wallet" | "generic";
       tee_secured?: boolean;
+      /**
+       * Optional HTTP 402 Payment Required endpoint URL this wallet exposes for pay-per-call settlements (RFC-style x402 flow, see economics.payment_gateways.x402 for the top-level enable flag). Clients hit this URL, receive a 402 with payment instructions referencing the wallet address, settle, then retry the original request.
+       */
+      x402_endpoint?: string;
       [k: string]: unknown | undefined;
     }[];
     payment_gateways?: {
@@ -591,6 +608,30 @@ export interface Signature {
   canonicalization?: "JCS" | "RFC8785";
 }
 /**
+ * Optional zero-knowledge KYC proof attesting to identity properties (tier, jurisdiction, age, etc.) without revealing the underlying data. Verified by packages/aix-zkkyc ProofVerifier. Replay protection is handled at verification time via the nullifier registry; presence of this field does not by itself confer KYC status.
+ */
+export interface ZKProof {
+  /**
+   * Groth16 proof object as produced by snarkjs. Free-form because the snarkjs shape (a, b, c, protocol, curve) is not stable across versions.
+   */
+  proof: {
+    [k: string]: unknown | undefined;
+  };
+  /**
+   * Public inputs to the proof — decimal-encoded field elements as strings
+   */
+  publicSignals: string[];
+  /**
+   * Unique proof identifier used by NullifierRegistry to prevent replay attacks. Recommended: SHA-256 hex.
+   */
+  nullifier: string;
+  timestamp?: ISODateTime;
+  /**
+   * Identifier of the circuit that produced this proof (e.g. pkyc-v1, age-over-18-v2). Recommended for verifier dispatch.
+   */
+  circuit?: string;
+}
+/**
  * Optional Meta Arbiter runtime configuration — wires into the agent's orchestration layer
  */
 export interface MetaArbiterConfig {
@@ -641,6 +682,33 @@ export interface MetaArbiterConfig {
    * Target cognitive growth milestone level (GrowthMonitor)
    */
   growth_milestone_level?: "beginner" | "intermediate" | "advanced" | "expert";
+}
+/**
+ * Zero-knowledge proof structure (Groth16). Mirrors the ZKProof interface in packages/aix-zkkyc/src/ProofVerifier.ts so on-chain proofs round-trip through the manifest without re-encoding.
+ *
+ * This interface was referenced by `AIXFormat`'s JSON-Schema
+ * via the `definition` "ZKProof".
+ */
+export interface ZKProof1 {
+  /**
+   * Groth16 proof object as produced by snarkjs. Free-form because the snarkjs shape (a, b, c, protocol, curve) is not stable across versions.
+   */
+  proof: {
+    [k: string]: unknown | undefined;
+  };
+  /**
+   * Public inputs to the proof — decimal-encoded field elements as strings
+   */
+  publicSignals: string[];
+  /**
+   * Unique proof identifier used by NullifierRegistry to prevent replay attacks. Recommended: SHA-256 hex.
+   */
+  nullifier: string;
+  timestamp?: ISODateTime;
+  /**
+   * Identifier of the circuit that produced this proof (e.g. pkyc-v1, age-over-18-v2). Recommended for verifier dispatch.
+   */
+  circuit?: string;
 }
 /**
  * Meta Arbiter — 'العقل المدبر' — orchestration config for the agent's internal subsystem controller. Controls activation thresholds, coordination strategy, and growth monitoring.


### PR DESCRIPTION
Step #A of the planned 5-PR sequence to close the gap between the AGENT.md acceptance criteria for Task 1 (Schema) + Task 2 (Crypto identity) and what `schemas/aix.schema.json` actually expresses today. Pure schema work, fully backward compatible, sets the foundation every subsequent PR builds on.

Every new field is optional, no entries are added to any `required` array, and the pre-existing pass/fail split across the 5 golden manifests is preserved exactly (verified by running ajv against `schemas/aix.schema.json` on both `main` and this branch — same 2/5 pass on each side).

## New fields

| Field | Purpose |
|---|---|
| `aix_version` (top-level) | Optional SemVer shorthand for the schema version this manifest targets. Resolution order for consumers: `aix_version` > `meta.format_version` > version parsed from `$id` > `0.369.0` fallback. |
| `skills[].safety_score` | 0-10 numeric safety score per MCP-style tool. 10 = sandboxed read-only; 0 = arbitrary code exec. Consumers can gate autonomous dispatch on it (e.g. require >= 7). Default 5 (unknown / standard). |
| `identity_layer.pi_uid_anchor` | SHA-256 hex (64 chars) of a verified Pi Network user ID. Binds a `did:axiom` identity to a Pi user without revealing the UID. Produced by `packages/pi-kyc` `hashPiUid()`. |
| `identity_layer.zk_proof` | Groth16 zero-knowledge KYC proof. Shape mirrors `ZKProof` in `packages/aix-zkkyc/src/ProofVerifier.ts` (proof, publicSignals[], nullifier, optional timestamp + circuit) so proofs round-trip through the manifest without re-encoding. Replay protection stays in `NullifierRegistry` at verify time. |
| `economics.wallets[].x402_endpoint` | Per-wallet HTTP 402 Payment Required URL for pay-per-call settlement. Complements the existing top-level `economics.payment_gateways.x402.enabled` flag with a concrete endpoint. |

Also:

- `meta.format_version` description tightened to clarify it co-exists with the new `aix_version` shorthand and that consumers SHOULD treat them as equal (a validator MAY warn on disagreement).
- New `$defs.ZKProof` for re-use and clear documentation of the Groth16 shape.
- Top-level `$comment` updated to record the v0.369.0+ additions.
- `types/parser.d.ts` regenerated with `json2ts -i schemas/aix.schema.json -o types/parser.d.ts --strictIndexSignatures --unreachableDefinitions` (the canonical command from `package.json` `generate:types:unified` and from `.github/workflows/schema-drift-check.yml`). Diff is purely additive — no existing export renamed or narrowed.
- New fixture `tests/fixtures/schema/v0.369.0-optional-fields.aix.json` exercising every new field, plus a `README.md` documenting how to re-validate it locally with the bundled ajv setup.

## What's out of scope (follow-up PRs from the agreed plan)

| PR | Scope |
|---|---|
| #B | JSON-LD `@context` (`schemas/aix-context.jsonld`) + `--jsonld` validator flag |
| #C | `packages/aix-core/src/did/resolver.ts` — DID parsing, Pi anchor verification, offline fallback |
| #D | Replace TrustChain HMAC with Ed25519 detached signatures + `verifyChain()` walker + `.aix.trustchain` export |
| #E | `human_approval` schema field + `verifyHumanApproval()` API, wired to TrustChain entries |

Pre-existing fixture/schema drift (3 of 5 golden manifests fail strict ajv validation against the schema today because of stray `build_provenance` and `identity_layer.{provider, verification}` fields the schema doesn't define) is explicitly NOT addressed here. The same 3 fixtures fail on `main` with the unchanged schema; this is a separate clean-up and would scope-creep an otherwise minimal schema bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added zero-knowledge proof support in identity layer for enhanced verification capabilities
  * Introduced safety scoring for skills with 0–10 scale
  * Added x402 pay-per-call endpoint support for wallet settlement options
  * Added manifest version shorthand field

* **Documentation**
  * Schema fixture validation guide added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moeabdelaziz007/aix-format/pull/154)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->