### PR TITLE
feat(axiom-identity): introduce @axiom/identity canonical package (Phase 1.2)

### DIFF
--- a/packages/axiom-identity/README.md
+++ b/packages/axiom-identity/README.md
@@ -1,0 +1,101 @@
+# @axiom/identity
+
+Canonical AIX identity primitives. The second canonical core package per [RFC-001](../../docs/rfc/RFC-001-canonical-core.md). Ships:
+
+- **RFC 8785 JCS** — deterministic JSON canonicalization with surrogate validation. Two parties producing the same logical object always produce the same canonical byte string.
+- **Ed25519** — real `@noble/ed25519` signing and verification. Sign canonical JSON, get a `SignedPayload<T>` carrying the SHA-256 hash, the base64url signature, and the base64url public key. Verify reverses the chain.
+- **DID translator** — lossless conversion between `did:axiom:axiomid.app:<id>` and `did:web:axiomid.app:<id>`. The `<id>` segment is preserved byte-for-byte; only the method prefix swaps.
+- **Pi Network domain claim** — full claim/verify flow for the well-known endpoint `https://<domain>/.well-known/pi-claim.json`. Strict DID-domain binding and URL host check are enforced.
+
+Zero native bindings. Works on Node, Vercel Edge, Cloudflare Workers identically.
+
+## What this package replaces
+
+| Old location | Replacement |
+|---|---|
+| `iqra/src/lib/iqra/14-aix/canonical.ts` | `@axiom/identity/canonical` |
+| `iqra/src/lib/iqra/14-aix/ed25519_signer.ts` | `@axiom/identity/ed25519` |
+| `iqra/src/lib/iqra/14-aix/did_translator.ts` | `@axiom/identity/did` |
+| `iqra/src/lib/iqra/14-aix/pi_network_claim.ts` | `@axiom/identity/pi` |
+| Scattered Ed25519 attempts in `aix-format/packages/aix-core` | wrapper over this package |
+| Pi-KYC primitives in `aix-format/packages/pi-kyc` | wrapper over `@axiom/identity/pi` |
+
+## Usage
+
+### Sign and verify a manifest
+
+```ts
+import { generateKeyPair, signPayload, verifySignedPayload } from '@axiom/identity';
+
+const { privateKey } = generateKeyPair();
+const signed = signPayload({ hello: 'world' }, privateKey);
+
+console.log(signed.payload_hash);        // sha256 hex of canonical JSON
+console.log(signed.signature.value);      // base64url Ed25519 signature
+console.log(signed.publicKey.value);      // base64url public key
+
+const ok = verifySignedPayload(signed);   // true
+```
+
+### Translate between DID forms
+
+```ts
+import { toAxiomDID, toWebDID, translateDID } from '@axiom/identity';
+
+const axiom = toAxiomDID('iqra-sovereign');
+//   "did:axiom:axiomid.app:iqra-sovereign"
+
+const { web, id } = translateDID(axiom);
+//   web: "did:web:axiomid.app:iqra-sovereign"
+//   id:  "iqra-sovereign"
+```
+
+### Canonicalize a payload
+
+```ts
+import { canonicalizeJSON, canonicalizeJSONBytes } from '@axiom/identity/canonical';
+
+canonicalizeJSON({ b: 2, a: 1 });
+// '{"a":1,"b":2}'
+
+canonicalizeJSON({ unicode: '😀' });
+// '{"unicode":"😀"}'   (valid surrogate pair preserved)
+
+canonicalizeJSON({ bad: '\uD800' });
+// throws TypeError: JCS: lone high surrogate at index 0 (U+D800)
+```
+
+### Issue and verify a Pi Network domain claim
+
+```ts
+import { bootstrapPiClaim, verifyPiClaim } from '@axiom/identity/pi';
+
+const { artifact, privateKey } = bootstrapPiClaim({
+  owner_id: 'iqra-sovereign',
+  app_id: 'pi-app-xxxx',
+  environment: 'production',
+});
+
+// host artifact at https://axiomid.app/.well-known/pi-claim.json
+// then anywhere:
+const result = verifyPiClaim(artifact);   // { ok: true }
+```
+
+## Constitutional alignment
+
+This package implements the **Three Sovereign Truths** from [`AXIOM.md`](../../AXIOM.md):
+
+1. **No Mocks** — real Ed25519, real SHA-512, real SHA-256, no shims.
+2. **No Hallucinations** — JCS rejects non-finite numbers, BigInts, lone surrogates, and circular structures. The verifier recomputes the canonical digest before checking the signature; tampering on either side breaks verification deterministically.
+3. **Memory Governance is the Heart** — every `SignedPayload` carries the canonical hash inline. Two parties cannot disagree on what was signed.
+
+## Provenance
+
+All four modules are extracted verbatim from `iqra/src/lib/iqra/14-aix/`:
+
+- `canonical.ts` ← `canonical.ts`
+- `ed25519.ts` ← `ed25519_signer.ts`
+- `did.ts` ← `did_translator.ts` (with `AXIOM_AUTHORITY` now sourced from `@axiom/schema/version`)
+- `pi.ts` ← `pi_network_claim.ts`
+
+The iqra-side files become re-export shims in Phase 1.2's L2 migration, then are removed in the next minor release.

--- a/packages/axiom-identity/package.json
+++ b/packages/axiom-identity/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@axiom/identity",
+  "version": "1.3.0",
+  "description": "Canonical AIX identity primitives: Axiom DID translator, Ed25519 sign/verify, RFC 8785 JCS canonicalization, and Pi Network domain-claim flow. Edge-safe, no native bindings.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./canonical": {
+      "types": "./dist/canonical.d.ts",
+      "default": "./dist/canonical.js"
+    },
+    "./ed25519": {
+      "types": "./dist/ed25519.d.ts",
+      "default": "./dist/ed25519.js"
+    },
+    "./did": {
+      "types": "./dist/did.d.ts",
+      "default": "./dist/did.js"
+    },
+    "./pi": {
+      "types": "./dist/pi.d.ts",
+      "default": "./dist/pi.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "keywords": [
+    "aix",
+    "axiom",
+    "identity",
+    "did",
+    "ed25519",
+    "jcs",
+    "rfc-8785",
+    "pi-network",
+    "sovereign-protocol"
+  ],
+  "sideEffects": false,
+  "license": "Apache-2.0",
+  "author": "Mohamed H Abdelaziz",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Moeabdelaziz007/aix-format.git",
+    "directory": "packages/axiom-identity"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@axiom/schema": "workspace:*",
+    "@noble/ed25519": "^2.3.0",
+    "@noble/hashes": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/axiom-identity/src/canonical.ts
+++ b/packages/axiom-identity/src/canonical.ts
@@ -1,0 +1,146 @@
+/**
+ * 🧮 JSON Canonicalization (RFC 8785 / JCS)
+ *
+ * AIX signs canonical JSON, not raw JSON. Two parties that produced the
+ * same logical object must produce the exact same byte string before
+ * hashing, otherwise signatures don't verify across runtimes.
+ *
+ * Implementation: deterministic stringify per RFC 8785:
+ *   - Object keys sorted by UTF-16 code units (UCS-2 lexicographic).
+ *   - No insignificant whitespace.
+ *   - Numbers serialized per ECMA-262 ToString (V8/Node give us this).
+ *   - Strings escaped per JSON spec.
+ *   - Disallows: undefined, functions, symbols, BigInt, circular refs,
+ *     NaN, +/-Infinity. These would silently mutate during JSON.stringify.
+ *
+ * No external dependencies. Edge/Workers safe.
+ *
+ * Provenance: extracted verbatim from
+ * iqra/src/lib/iqra/14-aix/canonical.ts. Behaviour and test parity
+ * preserved.
+ */
+
+function escapeString(s: string): string {
+  // JSON spec: must escape ", \, control chars (U+0000..U+001F).
+  // Non-ASCII characters stay as-is so the canonical byte length
+  // matches what other compliant canonicalizers emit.
+  //
+  // RFC 8785 §3.2.2.2 mandates that an implementation MUST fail when
+  // the input contains an unpaired UTF-16 surrogate. Different
+  // implementations can otherwise disagree on the canonical bytes
+  // (lone high surrogate vs replacement char vs literal) and produce
+  // non-interoperable signatures for the same logical string.
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const ch = s.charCodeAt(i);
+
+    // High surrogate (D800..DBFF): MUST be followed by a low surrogate.
+    if (ch >= 0xd800 && ch <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : -1;
+      if (next < 0xdc00 || next > 0xdfff) {
+        throw new TypeError(
+          `JCS: lone high surrogate at index ${i} (U+${ch.toString(16).toUpperCase()})`,
+        );
+      }
+      // Pair is valid; emit both code units verbatim and skip the low.
+      out += s[i] + s[i + 1];
+      i++;
+      continue;
+    }
+    // Low surrogate (DC00..DFFF) without a preceding high surrogate.
+    if (ch >= 0xdc00 && ch <= 0xdfff) {
+      throw new TypeError(
+        `JCS: lone low surrogate at index ${i} (U+${ch.toString(16).toUpperCase()})`,
+      );
+    }
+
+    if (ch === 0x22) {
+      out += '\\"';
+    } else if (ch === 0x5c) {
+      out += '\\\\';
+    } else if (ch === 0x08) {
+      out += '\\b';
+    } else if (ch === 0x09) {
+      out += '\\t';
+    } else if (ch === 0x0a) {
+      out += '\\n';
+    } else if (ch === 0x0c) {
+      out += '\\f';
+    } else if (ch === 0x0d) {
+      out += '\\r';
+    } else if (ch < 0x20) {
+      out += '\\u' + ch.toString(16).padStart(4, '0');
+    } else {
+      out += s[i];
+    }
+  }
+  out += '"';
+  return out;
+}
+
+function serializeNumber(n: number): string {
+  if (!Number.isFinite(n)) {
+    throw new TypeError(`JCS: non-finite number not allowed: ${n}`);
+  }
+  // Integer fast-path matches the canonical form for safe integers.
+  if (Number.isInteger(n) && Math.abs(n) < 1e21) {
+    return String(n);
+  }
+  // ECMA-262 ToString already produces shortest round-trip form for
+  // doubles; that aligns with RFC 8785's reliance on ES number string.
+  return String(n);
+}
+
+function canonicalizeInner(value: unknown, seen: WeakSet<object>): string {
+  if (value === null) return 'null';
+
+  const t = typeof value;
+
+  if (t === 'boolean') return value ? 'true' : 'false';
+  if (t === 'number') return serializeNumber(value as number);
+  if (t === 'string') return escapeString(value as string);
+
+  if (t === 'undefined' || t === 'function' || t === 'symbol' || t === 'bigint') {
+    throw new TypeError(`JCS: unsupported value type: ${t}`);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new TypeError('JCS: circular structure');
+    seen.add(value);
+    const items = value.map((v) => canonicalizeInner(v, seen));
+    seen.delete(value);
+    return '[' + items.join(',') + ']';
+  }
+
+  // Plain object
+  const obj = value as Record<string, unknown>;
+  if (seen.has(obj)) throw new TypeError('JCS: circular structure');
+  seen.add(obj);
+
+  // RFC 8785: sort object keys by UTF-16 code units.
+  const keys = Object.keys(obj).sort();
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = obj[k];
+    if (v === undefined) continue; // RFC 8785 drops these.
+    parts.push(escapeString(k) + ':' + canonicalizeInner(v, seen));
+  }
+  seen.delete(obj);
+  return '{' + parts.join(',') + '}';
+}
+
+/**
+ * Produce the RFC 8785 / JCS canonical JSON string for `value`.
+ *
+ * Throws on circular refs, non-finite numbers, undefined-leaves outside
+ * objects, BigInts, functions, or Symbols. Those are not legal in a
+ * deterministic signing payload.
+ */
+export function canonicalizeJSON(value: unknown): string {
+  return canonicalizeInner(value, new WeakSet());
+}
+
+/** Convenience: UTF-8 byte view of the canonical string. */
+export function canonicalizeJSONBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalizeJSON(value));
+}

--- a/packages/axiom-identity/src/did.ts
+++ b/packages/axiom-identity/src/did.ts
@@ -1,0 +1,80 @@
+/**
+ * 🆔 DID Translator — Axiom ⇄ Web
+ *
+ * Two forms of axiomid.app-rooted DIDs coexist in the stack:
+ *   - `did:web:axiomid.app:<id>`   — W3C standard, resolvable via
+ *     HTTPS at the well-known endpoint.
+ *   - `did:axiom:axiomid.app:<id>` — AIX sovereign method, lets
+ *     AIX-aware resolvers skip the web fetch and hit the Axiom
+ *     registry directly.
+ *
+ * This module is a lossless translator between the two forms. The
+ * `<id>` portion is preserved byte-for-byte; only the method prefix
+ * swaps. Both forms resolve to the same underlying agent. Use this
+ * when emitting manifests; never reimplement the regex elsewhere.
+ *
+ * Provenance: extracted from
+ * iqra/src/lib/iqra/14-aix/did_translator.ts. Authority constant
+ * now imported from `@axiom/schema/version` so there is a single
+ * source of truth for the locked-const value `axiomid.app`.
+ */
+
+import { AXIOM_AUTHORITY } from '@axiom/schema';
+import type { AxiomDID, DID } from '@axiom/schema';
+
+const AXIOM_PREFIX = `did:axiom:${AXIOM_AUTHORITY}:` as const;
+const WEB_PREFIX = `did:web:${AXIOM_AUTHORITY}:` as const;
+
+// Permissible id chars (matches AIX schema and W3C generic DID grammar).
+const ID_RE = /^[a-zA-Z0-9._\-]+$/;
+
+function assertValidId(id: string): void {
+  if (!ID_RE.test(id)) {
+    throw new Error(`DID id contains illegal characters: ${id}`);
+  }
+}
+
+/** Build a sovereign `did:axiom:axiomid.app:<id>` from a raw id. */
+export function toAxiomDID(id: string): AxiomDID {
+  assertValidId(id);
+  return `${AXIOM_PREFIX}${id}` as AxiomDID;
+}
+
+/** Build a `did:web:axiomid.app:<id>` (resolvable via .well-known). */
+export function toWebDID(id: string): DID {
+  assertValidId(id);
+  return `${WEB_PREFIX}${id}` as DID;
+}
+
+/** Convert between the two forms, preserving the id segment. */
+export function translateDID(input: string): { axiom: AxiomDID; web: DID; id: string } {
+  let id: string;
+  if (input.startsWith(AXIOM_PREFIX)) {
+    id = input.slice(AXIOM_PREFIX.length);
+  } else if (input.startsWith(WEB_PREFIX)) {
+    id = input.slice(WEB_PREFIX.length);
+  } else if (input.startsWith('did:web:')) {
+    // Tolerate other did:web authorities by rebinding to axiomid.app.
+    const tail = input.slice('did:web:'.length);
+    const parts = tail.split(':');
+    id = parts[parts.length - 1] ?? '';
+  } else {
+    throw new Error(`Unsupported DID method for axiomid.app translation: ${input}`);
+  }
+  assertValidId(id);
+  return { axiom: toAxiomDID(id), web: toWebDID(id), id };
+}
+
+/** Quick predicate: is this string an `axiomid.app`-rooted DID (either form)? */
+export function isAxiomRooted(value: string): boolean {
+  return value.startsWith(AXIOM_PREFIX) || value.startsWith(WEB_PREFIX);
+}
+
+/** Extract the bare id segment without the method prefix. */
+export function didId(input: string): string {
+  return translateDID(input).id;
+}
+
+// Re-export the locked authority so callers that only depend on this
+// module's sub-export do not need to also import from @axiom/schema.
+export { AXIOM_AUTHORITY };

--- a/packages/axiom-identity/src/ed25519.ts
+++ b/packages/axiom-identity/src/ed25519.ts
@@ -1,0 +1,213 @@
+/**
+ * ✍️ Real Ed25519 signing for AIX manifests.
+ *
+ * Uses @noble/ed25519 (pure JS, audited, edge/worker safe) for the
+ * signing primitive and @noble/hashes/sha256 for canonical hashing.
+ * Both have zero native bindings, so this works on Vercel Edge, Node,
+ * and Cloudflare Workers identically.
+ *
+ * AIX signing protocol (v0.369.0):
+ *   1. canonicalize payload via RFC 8785 (JCS).
+ *   2. SHA-256 the canonical bytes → 32-byte digest.
+ *   3. Ed25519 sign the digest → 64-byte signature.
+ *   4. Encode public key + signature as base64url for the manifest.
+ *
+ * Verification reverses steps 1-4. The verifier must use the same
+ * canonicalizer (this module guarantees that).
+ *
+ * Provenance: extracted from
+ * iqra/src/lib/iqra/14-aix/ed25519_signer.ts. Edge-safe codecs and
+ * the @noble/ed25519 `etc` hash hooks preserved verbatim.
+ */
+
+import * as ed25519 from '@noble/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+import { sha512 } from '@noble/hashes/sha512';
+import { canonicalizeJSONBytes } from './canonical.js';
+
+// @noble/ed25519 v2.3 exposes two hash hooks on `etc`:
+//   - sha512Sync(...messages: Uint8Array[]): Uint8Array  → drives sign() / verify()
+//   - sha512Async(...messages: Uint8Array[]): Promise<Uint8Array> → drives *Async()
+//
+// There is NO `hashes` namespace on this version of the library; the
+// earlier code that wrote to `ed25519.hashes.sha512` threw on import
+// (`Cannot set properties of undefined`). We wire the @noble/hashes
+// SHA-512 implementation into the two `etc` hooks so callers can use
+// the sync API (`sign` / `verify`) safely on Node, Vercel Edge, and
+// Cloudflare Workers — none of which ship an ambient SHA-512.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(ed25519 as any).etc.sha512Sync = (...m: Uint8Array[]): Uint8Array =>
+  sha512(concat(m));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(ed25519 as any).etc.sha512Async = async (...m: Uint8Array[]): Promise<Uint8Array> =>
+  sha512(concat(m));
+
+function concat(arrs: Uint8Array[]): Uint8Array {
+  let len = 0;
+  for (const a of arrs) len += a.length;
+  const out = new Uint8Array(len);
+  let off = 0;
+  for (const a of arrs) {
+    out.set(a, off);
+    off += a.length;
+  }
+  return out;
+}
+
+// ── base64url helpers (no Buffer dependency, edge-safe) ───────────────────────
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  // btoa is available on Edge/Workers/modern Node.
+  const b64 = typeof btoa === 'function'
+    ? btoa(bin)
+    : Buffer.from(bytes).toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/') +
+    '==='.slice((b64url.length + 3) % 4);
+  if (typeof atob === 'function') {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) out += bytes[i].toString(16).padStart(2, '0');
+  return out;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('hexToBytes: odd length');
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface Ed25519KeyPair {
+  /** 32-byte raw secret key (seed). */
+  privateKey: Uint8Array;
+  /** 32-byte raw public key. */
+  publicKey: Uint8Array;
+}
+
+export interface Ed25519KeyPairB64 {
+  privateKey: string;
+  publicKey: string;
+}
+
+export interface SignedPayload<T> {
+  payload: T;
+  /** SHA-256 of the canonical JSON bytes, hex-encoded. */
+  payload_hash: string;
+  signature: {
+    algorithm: 'Ed25519';
+    value: string; // base64url
+    canonicalization: 'JCS';
+  };
+  publicKey: {
+    algorithm: 'Ed25519';
+    value: string; // base64url
+    encoding: 'base64url';
+  };
+}
+
+// ── Core API ─────────────────────────────────────────────────────────────────
+
+/** Generate a fresh Ed25519 keypair using the runtime CSPRNG. */
+export function generateKeyPair(): Ed25519KeyPair {
+  const privateKey = ed25519.utils.randomPrivateKey();
+  const publicKey = ed25519.getPublicKey(privateKey);
+  return { privateKey, publicKey };
+}
+
+/** Generate a keypair and return its base64url-encoded form. */
+export function generateKeyPairB64(): Ed25519KeyPairB64 {
+  const kp = generateKeyPair();
+  return {
+    privateKey: bytesToBase64Url(kp.privateKey),
+    publicKey: bytesToBase64Url(kp.publicKey),
+  };
+}
+
+/** Derive the public key from a raw 32-byte secret. */
+export function publicKeyFromPrivate(privateKey: Uint8Array): Uint8Array {
+  return ed25519.getPublicKey(privateKey);
+}
+
+/** Sign the SHA-256 digest of the canonical JSON of `payload`. */
+export function signPayload<T>(payload: T, privateKey: Uint8Array): SignedPayload<T> {
+  const canonical = canonicalizeJSONBytes(payload);
+  const digest = sha256(canonical);
+  const sig = ed25519.sign(digest, privateKey);
+  const pub = ed25519.getPublicKey(privateKey);
+  return {
+    payload,
+    payload_hash: bytesToHex(digest),
+    signature: {
+      algorithm: 'Ed25519',
+      value: bytesToBase64Url(sig),
+      canonicalization: 'JCS',
+    },
+    publicKey: {
+      algorithm: 'Ed25519',
+      value: bytesToBase64Url(pub),
+      encoding: 'base64url',
+    },
+  };
+}
+
+/**
+ * Verify that `signature` was produced by the holder of the private
+ * key matching `publicKey`, over the canonical JSON of `payload`.
+ *
+ * Returns true only when:
+ *   - the recomputed canonical digest matches `payload_hash`, AND
+ *   - the Ed25519 verification succeeds against that digest.
+ */
+export function verifySignedPayload<T>(signed: SignedPayload<T>): boolean {
+  try {
+    const canonical = canonicalizeJSONBytes(signed.payload);
+    const digest = sha256(canonical);
+    if (bytesToHex(digest) !== signed.payload_hash) return false;
+    const sig = base64UrlToBytes(signed.signature.value);
+    const pub = base64UrlToBytes(signed.publicKey.value);
+    return ed25519.verify(sig, digest, pub);
+  } catch {
+    return false;
+  }
+}
+
+/** Low-level: sign arbitrary bytes (rarely needed; prefer signPayload). */
+export function signBytes(bytes: Uint8Array, privateKey: Uint8Array): Uint8Array {
+  const digest = sha256(bytes);
+  return ed25519.sign(digest, privateKey);
+}
+
+/** Low-level: verify arbitrary bytes. */
+export function verifyBytes(bytes: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean {
+  try {
+    const digest = sha256(bytes);
+    return ed25519.verify(signature, digest, publicKey);
+  } catch {
+    return false;
+  }
+}
+
+export const codec = {
+  bytesToBase64Url,
+  base64UrlToBytes,
+  bytesToHex,
+  hexToBytes,
+};

--- a/packages/axiom-identity/src/index.ts
+++ b/packages/axiom-identity/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * 🆔 @axiom/identity — Canonical AIX identity primitives.
+ *
+ * Public surface (rich, single import):
+ *   - canonical: `canonicalizeJSON`, `canonicalizeJSONBytes`
+ *   - ed25519:   `generateKeyPair`, `signPayload`, `verifySignedPayload`,
+ *                `signBytes`, `verifyBytes`, `codec`, plus types.
+ *   - did:       `toAxiomDID`, `toWebDID`, `translateDID`, `isAxiomRooted`,
+ *                `didId`, `AXIOM_AUTHORITY`.
+ *   - pi:        `createPiClaim`, `verifyPiClaim`, `bootstrapPiClaim`,
+ *                plus types.
+ *
+ * Sub-exports also available for tree-shaking:
+ *   `@axiom/identity/canonical` `/ed25519` `/did` `/pi`.
+ *
+ * Constitutional alignment (AXIOM.md):
+ *   - No mocks. Real Ed25519 via @noble/ed25519; real SHA-512 via
+ *     @noble/hashes; no native bindings; edge-safe codecs.
+ *   - No hallucinations. JCS canonicalization is RFC 8785 compliant
+ *     and rejects unpaired surrogates / non-finite numbers.
+ *   - Memory governance is the heart. Every signed payload carries
+ *     its own canonical hash; verifySignedPayload recomputes from
+ *     the payload, so tampering is detectable bit-exactly.
+ */
+
+export * from './canonical.js';
+export * from './ed25519.js';
+export * from './did.js';
+export * from './pi.js';

--- a/packages/axiom-identity/src/pi.ts
+++ b/packages/axiom-identity/src/pi.ts
@@ -1,0 +1,165 @@
+/**
+ * 🥧 Pi Network Domain Claim — sovereign verification for axiomid.app
+ *
+ * Pi Network's dev browser allows a developer to "claim" a domain by
+ * proving control of it. The claim flow (as used for axiomid.app):
+ *
+ *   1. Generate (or load) the agent's Ed25519 keypair (this module
+ *      uses the signer in `./ed25519.js`).
+ *   2. Produce a canonical claim manifest covering:
+ *        { domain, owner_did, app_id, environment, issued_at, nonce }
+ *   3. Sign the canonical JSON of the manifest with the Ed25519 key.
+ *   4. Publish the signature + public key at the well-known endpoint
+ *        https://<domain>/.well-known/pi-claim.json
+ *      so Pi's verifier (or any third party) can fetch & verify.
+ *
+ * This module produces and verifies that artifact deterministically.
+ * No network calls. The caller is responsible for hosting the JSON at
+ * the well-known path. We keep the cryptography here so the same code
+ * is used to claim, rotate keys, and verify external claims.
+ *
+ * Provenance: extracted from
+ * iqra/src/lib/iqra/14-aix/pi_network_claim.ts. Strict DID-domain
+ * binding and well-known URL host check preserved verbatim — both
+ * were security fixes added in iqra after a prior loose match
+ * accepted attacker-controlled origins.
+ */
+
+import { signPayload, verifySignedPayload, generateKeyPair } from './ed25519.js';
+import type { SignedPayload } from './ed25519.js';
+import { toAxiomDID, AXIOM_AUTHORITY } from './did.js';
+import type { AxiomDID } from '@axiom/schema';
+
+export interface PiClaimManifest {
+  domain: string;
+  owner_did: AxiomDID;
+  app_id: string;
+  environment: 'sandbox' | 'production';
+  issued_at: string;
+  nonce: string;
+  /** Optional human-readable note shown in the Pi dev browser console. */
+  note?: string;
+}
+
+export interface PiClaimArtifact extends SignedPayload<PiClaimManifest> {
+  /** Convenience: the URL where this artifact is expected to live. */
+  well_known_url: string;
+}
+
+export interface PiClaimInput {
+  domain?: string; // defaults to axiomid.app
+  owner_id: string; // the bare id portion, e.g. "iqra-sovereign"
+  app_id: string;
+  environment: 'sandbox' | 'production';
+  privateKey: Uint8Array;
+  /** Optional override; otherwise we use Date.now(). */
+  issued_at?: Date;
+  /** Optional override; otherwise we generate a 16-byte hex nonce. */
+  nonce?: string;
+  note?: string;
+}
+
+function randomNonceHex(bytes: number = 16): string {
+  const buf = new Uint8Array(bytes);
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    globalThis.crypto.getRandomValues(buf);
+  } else {
+    // No CSPRNG available; bail out rather than silently weakening.
+    throw new Error('pi: no CSPRNG available in this runtime.');
+  }
+  let out = '';
+  for (let i = 0; i < buf.length; i++) out += buf[i].toString(16).padStart(2, '0');
+  return out;
+}
+
+/**
+ * Build and sign a Pi Network domain-claim artifact for the agent.
+ * The returned artifact is ready to be JSON.stringify'd and hosted at
+ * `well_known_url`.
+ */
+export function createPiClaim(input: PiClaimInput): PiClaimArtifact {
+  const domain = (input.domain ?? AXIOM_AUTHORITY).trim();
+  if (!domain) throw new Error('createPiClaim: domain is required');
+
+  const owner_did = toAxiomDID(input.owner_id);
+  const issued_at = (input.issued_at ?? new Date()).toISOString();
+  const nonce = input.nonce ?? randomNonceHex();
+
+  const manifest: PiClaimManifest = {
+    domain,
+    owner_did,
+    app_id: input.app_id,
+    environment: input.environment,
+    issued_at,
+    nonce,
+  };
+  if (input.note) manifest.note = input.note;
+
+  const signed = signPayload(manifest, input.privateKey);
+  return {
+    ...signed,
+    well_known_url: `https://${domain}/.well-known/pi-claim.json`,
+  };
+}
+
+/**
+ * Verify an artifact fetched from a well-known URL. Returns:
+ *   - ok: true only when signature verifies AND domain matches AND
+ *         owner_did is rooted on the same domain.
+ *   - reason: short failure tag on the ok=false path.
+ */
+export function verifyPiClaim(
+  artifact: PiClaimArtifact,
+): { ok: true } | { ok: false; reason: string } {
+  if (!verifySignedPayload(artifact)) {
+    return { ok: false, reason: 'BAD_SIGNATURE' };
+  }
+  const { domain, owner_did } = artifact.payload;
+
+  // Strict DID format: must be exactly `did:axiom:<domain>:<id>` where
+  // <id> follows the AIX-schema id charset. A loose substring match
+  // (`owner_did.includes(`:${domain}:`)`) would accept hostile methods
+  // like `did:evil:axiomid.app:x` simply because they contain the
+  // domain as a path segment. We anchor on the full string instead.
+  const escapedDomain = domain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const STRICT_AXIOM_DID = new RegExp(
+    `^did:axiom:${escapedDomain}:[a-zA-Z0-9._\\-]+$`,
+  );
+  if (!STRICT_AXIOM_DID.test(owner_did)) {
+    return { ok: false, reason: 'DID_DOMAIN_MISMATCH' };
+  }
+
+  // Validate the well-known URL ends with the expected path AND its host
+  // matches the claimed domain. The previous suffix-only check accepted
+  // any host (e.g. https://attacker.example/.well-known/pi-claim.json
+  // for a payload that claims domain=axiomid.app), which lets a signed
+  // artifact misdirect verifiers to an attacker-controlled origin.
+  if (!artifact.well_known_url.endsWith(`/.well-known/pi-claim.json`)) {
+    return { ok: false, reason: 'BAD_URL' };
+  }
+  try {
+    const url = new URL(artifact.well_known_url);
+    if (url.protocol !== 'https:') {
+      return { ok: false, reason: 'BAD_URL_SCHEME' };
+    }
+    if (url.hostname.toLowerCase() !== domain.toLowerCase()) {
+      return { ok: false, reason: 'URL_HOST_MISMATCH' };
+    }
+  } catch {
+    return { ok: false, reason: 'BAD_URL' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Convenience: generate a fresh keypair AND claim in one call. The
+ * caller should persist `privateKey` securely (env var, KMS, etc.)
+ * before publishing the artifact.
+ */
+export function bootstrapPiClaim(
+  input: Omit<PiClaimInput, 'privateKey'>,
+): { artifact: PiClaimArtifact; privateKey: Uint8Array; publicKey: Uint8Array } {
+  const kp = generateKeyPair();
+  const artifact = createPiClaim({ ...input, privateKey: kp.privateKey });
+  return { artifact, privateKey: kp.privateKey, publicKey: kp.publicKey };
+}

--- a/packages/axiom-identity/tsconfig.json
+++ b/packages/axiom-identity/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,25 @@ importers:
 
   packages/axiom-health: {}
 
+  packages/axiom-identity:
+    dependencies:
+      '@axiom/schema':
+        specifier: workspace:*
+        version: link:../axiom-schema
+      '@noble/ed25519':
+        specifier: ^2.3.0
+        version: 2.3.0
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
   packages/axiom-lint: {}
 
   packages/axiom-schema:
@@ -669,6 +688,9 @@ packages:
 
   '@next/bundle-analyzer@16.2.4':
     resolution: {integrity: sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==}
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -3237,6 +3259,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@noble/ed25519@2.3.0': {}
 
   '@noble/hashes@1.8.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
   - 'packages/aix-core'
   - 'packages/aix-rust-core'
   - 'packages/aix-zkkyc'
+  - 'packages/axiom-identity'
   - 'packages/axiom-schema'
   - 'packages/mcp-gateway'
   - 'packages/mcp-server'


### PR DESCRIPTION
Implements Phase 1.2 of [RFC-001](./docs/rfc/RFC-001-canonical-core.md). Extracts the AIX identity primitives (RFC 8785 JCS canonicalization, Ed25519 sign/verify, `did:axiom` ↔ `did:web` translator, Pi Network domain-claim flow) from `iqra/src/lib/iqra/14-aix/` into a single dedicated workspace package with one sub-export per concern. No code in `iqra/` or elsewhere is modified by this PR; consumers continue to read from `iqra/14-aix/` until the explicit L2 migration follow-up lands per RFC-001 §5.2.

The four iqra-side files are extracted verbatim, preserving the same behaviour and the security fixes the iqra reviewers had already landed: strict `did:axiom:<domain>:<id>` regex anchoring on the full DID string (no substring acceptance of hostile methods like `did:evil:axiomid.app:x`), well-known URL host + protocol check (rejects `https://attacker.example/.well-known/pi-claim.json` payloads claiming `domain=axiomid.app`), JCS lone-surrogate rejection per RFC 8785 §3.2.2.2, and the `@noble/ed25519` v2.3 `etc.sha512*` hash hooks so the sync `sign` / `verify` path works identically on Node, Vercel Edge, and Cloudflare Workers. The package root re-exports all four modules; sub-exports (`@axiom/identity/canonical`, `/ed25519`, `/did`, `/pi`) are also published for tree-shaking. `AXIOM_AUTHORITY` is now imported from `@axiom/schema/version` rather than redefined locally, so the locked-const value `axiomid.app` has exactly one source of truth.

Plumbing: `packages/axiom-identity` is added to `pnpm-workspace.yaml`, and `pnpm-lock.yaml` is regenerated so future workflows can install with `--frozen-lockfile`. All internal cross-file imports use `.js` suffixes for ESM resolution, matching the pattern set by `@axiom/schema`. Dependencies: `@axiom/schema` (workspace), `@noble/ed25519@^2.3.0`, `@noble/hashes@^1.8.0`. Zero native bindings, edge-safe codecs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `@axiom/identity` package with cryptographic identity primitives: deterministic JSON canonicalization, Ed25519 signing and verification, DID translation between Axiom and web formats, and Pi Network domain claim creation and verification.

* **Documentation**
  * Added comprehensive README documenting package purpose, identity primitives, usage examples, and implementation principles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moeabdelaziz007/aix-format/pull/162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->