### PR TITLE
feat(core-ci): rebuild CI pipeline + cross-package contract + MIGRATION.md

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,0 +1,128 @@
+name: Core CI (@axiom/schema + @axiom/identity)
+
+# The canonical core packages must satisfy four contracts on every PR:
+#   1. Lint clean       (dogfood axiom-lint on the canonical sources).
+#   2. Typecheck clean  (tsc --noEmit; emitted .d.ts files compile).
+#   3. Unit smoke green (round-trip sign/verify, DID translation,
+#                        canonical JSON byte equality, schema-version
+#                        constants match).
+#   4. Cross-package contract honoured (@axiom/identity sees the same
+#      `AXIOM_AUTHORITY` value that `@axiom/schema` exports; the
+#      generated types.gen.ts shape matches the rich types.ts surface
+#      on the load-bearing fields).
+#
+# Scoped to the canonical core paths so docs PRs and downstream
+# package work do not retrigger the whole stack.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/axiom-schema/**'
+      - 'packages/axiom-identity/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/core-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/axiom-schema/**'
+      - 'packages/axiom-identity/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/core-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint canonical core
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Run axiom-lint on @axiom/schema and @axiom/identity
+        run: |
+          node --experimental-strip-types packages/axiom-lint/bin/axiom-lint.js \
+            packages/axiom-schema packages/axiom-identity \
+            --fail-on error
+
+  typecheck:
+    name: Typecheck (${{ matrix.package }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - axiom-schema
+          - axiom-identity
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: tsc --noEmit on ${{ matrix.package }}
+        run: |
+          cd packages/${{ matrix.package }}
+          npx tsc --noEmit
+
+  unit-smoke:
+    name: Unit smoke (${{ matrix.package }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - axiom-schema
+          - axiom-identity
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Run ${{ matrix.package }} smoke tests
+        run: |
+          cd packages/${{ matrix.package }}
+          if [ -d test ]; then
+            # tsx loader so `.js` import specifiers (the form needed by
+            # Node ESM at runtime in the published dist) resolve to the
+            # original `.ts` sources during the in-tree CI run.
+            node --import tsx --test test/*.test.ts
+          else
+            echo "No test/ directory for ${{ matrix.package }} — skipping."
+          fi
+
+  contract:
+    name: Cross-package contract (@axiom/identity ⇄ @axiom/schema)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Run cross-package contract suite
+        run: |
+          cd packages/axiom-identity
+          node --import tsx --test test/contract.test.ts

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,126 @@
+# Migration Guide — Sovereign Core Packages
+
+One-page guide for migrating downstream consumers (iqra, aix-agent-skills, the studio runtime, third-party agents) to the new `@axiom/*` canonical packages. The full architecture lives in [`docs/rfc/RFC-001-canonical-core.md`](./docs/rfc/RFC-001-canonical-core.md); this file is the operational summary.
+
+## What changed
+
+Two canonical packages now ship from this repo as the single sources of truth for their concept:
+
+| Package | Owns | Status |
+|---|---|---|
+| `@axiom/schema` | AIX JSON Schema, TypeScript types, version pins, DID type guards | shipped (Phase 1.1) |
+| `@axiom/identity` | RFC 8785 JCS, Ed25519 sign/verify, DID translator, Pi Network claim | shipped (Phase 1.2) |
+
+The `axiom-format` repo also now ships:
+
+- [`AXIOM.md`](./AXIOM.md) — the Sovereign Stack constitution (read first by every agent).
+- A four-job Core CI (`core-ci.yml`): lint, typecheck, unit smoke, cross-package contract.
+- A schema drift check (`axiom-schema-codegen.yml`) — the rich TS types and the generated mirror cannot diverge silently.
+
+`AXIOM_AUTHORITY` is a single locked const exported from `@axiom/schema/version`; `@axiom/identity` imports it rather than redefining. A contract test fails the build if the two packages ever disagree.
+
+## Who is affected
+
+| Consumer | What to do |
+|---|---|
+| `iqra` (`src/lib/iqra/14-aix/`) | Replace local files with thin re-export shims for one minor release, then delete. See L2 migration below. |
+| `aix-agent-skills` (constitutional runtime) | Import from `@axiom/identity` directly. Drop the local `trust-chain.ts` once `@axiom/trustchain` (Phase 1.3) ships. |
+| Studio / third-party agents | Replace any direct AIX type imports with `@axiom/schema`. Replace any homegrown Ed25519 + canonicalization with `@axiom/identity`. |
+| Pure docs consumers | No action. |
+
+Anything that was reading `iqra/src/lib/iqra/14-aix/types.ts` directly today continues to work. The shim period is one minor release; pin behaviour will not change.
+
+## How to migrate
+
+### 1. Types and version pins
+
+```diff
+- import type { AIXManifest, AxiomDID } from 'iqra/14-aix/types';
+- import { AIX_FORMAT_VERSION } from 'iqra/14-aix/version';
++ import type { AIXManifest, AxiomDID } from '@axiom/schema';
++ import { AIX_FORMAT_VERSION, AXIOM_AUTHORITY } from '@axiom/schema';
+```
+
+The JSON schema itself is also available as a sub-export:
+
+```ts
+import schema from '@axiom/schema/schema.json' assert { type: 'json' };
+```
+
+### 2. Identity primitives
+
+```diff
+- import { canonicalizeJSON } from 'iqra/14-aix/canonical';
+- import { signPayload, verifySignedPayload } from 'iqra/14-aix/ed25519_signer';
+- import { toAxiomDID, translateDID } from 'iqra/14-aix/did_translator';
+- import { createPiClaim } from 'iqra/14-aix/pi_network_claim';
++ import { canonicalizeJSON } from '@axiom/identity/canonical';
++ import { signPayload, verifySignedPayload } from '@axiom/identity/ed25519';
++ import { toAxiomDID, translateDID } from '@axiom/identity/did';
++ import { createPiClaim } from '@axiom/identity/pi';
+```
+
+A rich single import also works:
+
+```ts
+import { signPayload, toAxiomDID, createPiClaim } from '@axiom/identity';
+```
+
+### 3. Sign + verify a manifest (before / after)
+
+Before:
+
+```ts
+import { signManifest } from 'iqra/14-aix/manifest_exporter';
+const signed = signManifest(manifest, privateKey);
+```
+
+After:
+
+```ts
+import { signPayload, verifySignedPayload } from '@axiom/identity';
+const signed = signPayload(manifest, privateKey);
+const ok = verifySignedPayload(signed);   // true on untampered round-trip
+```
+
+The output shape is unchanged: `{ payload, payload_hash, signature, publicKey }` with `signature.algorithm === 'Ed25519'` and `signature.canonicalization === 'JCS'`.
+
+### 4. Verify a Pi Network domain claim (before / after)
+
+Before:
+
+```ts
+import { verifyPiClaim } from 'iqra/14-aix/pi_network_claim';
+const ok = verifyPiClaim(artifact);
+```
+
+After:
+
+```ts
+import { verifyPiClaim } from '@axiom/identity/pi';
+const result = verifyPiClaim(artifact);
+//   { ok: true } | { ok: false, reason: 'BAD_SIGNATURE' | 'DID_DOMAIN_MISMATCH' | 'BAD_URL' | 'BAD_URL_SCHEME' | 'URL_HOST_MISMATCH' }
+```
+
+Note: the return shape moved from a plain boolean to a tagged result so callers can route on the failure reason without re-deriving it.
+
+## What CI guarantees on every PR
+
+`core-ci.yml` runs four jobs in parallel on every PR that touches the core packages or the lockfile:
+
+1. **Lint** — `axiom-lint` dogfooded against the canonical sources.
+2. **Typecheck** — `tsc --noEmit` per package; emitted `.d.ts` files must compile cleanly.
+3. **Unit smoke** — `node:test` over the per-package `test/*.test.ts` files. JCS edge cases, sign/verify round-trips, DID translation, Pi claim happy path + rejection paths.
+4. **Cross-package contract** — `packages/axiom-identity/test/contract.test.ts` imports from both packages plus reads the raw schema JSON. It fails the build if any of the following drift:
+   - `AXIOM_AUTHORITY` differs between the two packages.
+   - The schema's `identity_layer.authority.const` differs from `AXIOM_AUTHORITY`.
+   - Identity-emitted DIDs fail the schema-shipped `isAxiomDID` / `isDID` guards.
+   - Signed-payload algorithm or encoding enums fall outside the schema's `$defs.Signature` / `$defs.PublicKey` enums.
+
+A separate workflow (`axiom-schema-codegen.yml`) keeps `packages/axiom-schema/src/types.gen.ts` in sync with `schemas/aix.schema.json` via `json-schema-to-typescript`.
+
+If any of those four jobs fail, the PR is not safe to merge. There is no override flag.
+
+## Questions
+
+If a downstream integration breaks during migration, open an issue against `aix-format` with a minimal reproduction. The shim period for the iqra-side files is one minor release; after that, the local copies are removed.

--- a/packages/axiom-identity/package.json
+++ b/packages/axiom-identity/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
+    "tsx": "^4.19.2",
     "typescript": "^5.4.5"
   },
   "engines": {

--- a/packages/axiom-identity/test/contract.test.ts
+++ b/packages/axiom-identity/test/contract.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Cross-package contract: @axiom/identity ⇄ @axiom/schema.
+ *
+ * Drift between the two canonical core packages is the single failure
+ * mode this suite exists to detect. Any change that lets `@axiom/identity`
+ * see a different `AXIOM_AUTHORITY` value than `@axiom/schema` exports,
+ * or lets the schema's `identity_layer.authority` const drift away from
+ * what the identity package emits, MUST break this test before it ships.
+ *
+ * Run via Node 22's built-in test runner:
+ *   node --experimental-strip-types --test test/contract.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AXIOM_AUTHORITY as IDENTITY_AUTHORITY,
+  toAxiomDID,
+  toWebDID,
+  translateDID,
+  generateKeyPair,
+  signPayload,
+  verifySignedPayload,
+  createPiClaim,
+  verifyPiClaim,
+} from '../src/index.ts';
+import {
+  AXIOM_AUTHORITY as SCHEMA_AUTHORITY,
+  AIX_FORMAT_VERSION as SCHEMA_FORMAT_VERSION,
+  AIX_PROTOCOL_VERSION as SCHEMA_PROTOCOL_VERSION,
+  isAxiomDID,
+  isDID,
+} from '../../axiom-schema/src/index.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_JSON_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  'axiom-schema',
+  'schemas',
+  'aix.schema.json',
+);
+const schema = JSON.parse(readFileSync(SCHEMA_JSON_PATH, 'utf-8'));
+
+// ── authority lock: 3-way agreement ──────────────────────────────────────────
+
+test('@axiom/identity AXIOM_AUTHORITY equals @axiom/schema AXIOM_AUTHORITY', () => {
+  assert.strictEqual(
+    IDENTITY_AUTHORITY,
+    SCHEMA_AUTHORITY,
+    'Identity and Schema MUST export the same AXIOM_AUTHORITY value or DIDs drift.',
+  );
+});
+
+test('schema identity_layer.authority.const equals AXIOM_AUTHORITY', () => {
+  const authConst = schema.properties.identity_layer.properties.authority.const;
+  assert.strictEqual(
+    authConst,
+    IDENTITY_AUTHORITY,
+    'Schema authority const MUST equal the identity package authority. ' +
+      'If you bumped one, you MUST bump the other in the same PR.',
+  );
+});
+
+// ── DID round-trip across packages ───────────────────────────────────────────
+
+test('toAxiomDID outputs a string that isAxiomDID accepts', () => {
+  const did = toAxiomDID('contract-test-agent');
+  assert.ok(
+    isAxiomDID(did),
+    'Identity-emitted DIDs MUST pass the Schema-shipped type guard.',
+  );
+});
+
+test('translateDID outputs that isDID accepts in both forms', () => {
+  const out = translateDID(toAxiomDID('cross-test'));
+  assert.ok(isDID(out.axiom));
+  assert.ok(isDID(out.web));
+});
+
+test('toAxiomDID and toWebDID both contain AXIOM_AUTHORITY literally', () => {
+  const axiom = toAxiomDID('agent-7');
+  const web = toWebDID('agent-7');
+  assert.ok(
+    axiom.includes(`:${IDENTITY_AUTHORITY}:`),
+    'did:axiom output must embed AXIOM_AUTHORITY.',
+  );
+  assert.ok(
+    web.includes(`:${IDENTITY_AUTHORITY}:`),
+    'did:web output must embed AXIOM_AUTHORITY.',
+  );
+});
+
+// ── version pin agreement ────────────────────────────────────────────────────
+
+test('Schema AIX_FORMAT_VERSION is the major.minor of AIX_PROTOCOL_VERSION', () => {
+  const [maj, min] = SCHEMA_PROTOCOL_VERSION.split('.');
+  assert.strictEqual(
+    `${maj}.${min}`,
+    SCHEMA_FORMAT_VERSION,
+    'AIX_FORMAT_VERSION (major.minor) must match the leading two segments of AIX_PROTOCOL_VERSION.',
+  );
+});
+
+// ── signing round-trip uses canonical types ──────────────────────────────────
+
+test('signPayload returns the shape the schema names', () => {
+  const kp = generateKeyPair();
+  const signed = signPayload({ ping: 'pong' }, kp.privateKey);
+
+  // The schema's $defs.Signature requires { algorithm: 'Ed25519' | 'secp256k1',
+  // value: string, canonicalization?: 'JCS' | 'RFC8785' }. The identity
+  // package emits Ed25519 + JCS, both of which are valid choices in the
+  // schema's enum. This test guards against accidental drift in either side.
+  const sigEnum = schema.$defs.Signature.properties.algorithm.enum;
+  const canEnum = schema.$defs.Signature.properties.canonicalization.enum;
+
+  assert.ok(sigEnum.includes(signed.signature.algorithm));
+  assert.ok(canEnum.includes(signed.signature.canonicalization));
+
+  // Public key encoding contract.
+  const pkEnum = schema.$defs.PublicKey.properties.encoding.enum;
+  assert.ok(pkEnum.includes(signed.publicKey.encoding));
+
+  assert.ok(verifySignedPayload(signed));
+});
+
+// ── pi claim contract ────────────────────────────────────────────────────────
+
+test('createPiClaim emits a DID rooted on AXIOM_AUTHORITY', () => {
+  const kp = generateKeyPair();
+  const claim = createPiClaim({
+    owner_id: 'pi-contract-test',
+    app_id: 'pi-app-contract',
+    environment: 'production',
+    privateKey: kp.privateKey,
+  });
+  assert.strictEqual(claim.payload.domain, IDENTITY_AUTHORITY);
+  assert.ok(claim.payload.owner_did.startsWith(`did:axiom:${IDENTITY_AUTHORITY}:`));
+  assert.strictEqual(verifyPiClaim(claim).ok, true);
+});

--- a/packages/axiom-identity/test/smoke.test.ts
+++ b/packages/axiom-identity/test/smoke.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Smoke tests for @axiom/identity.
+ *
+ * Each test exercises one of the four sub-modules end-to-end so a
+ * regression in any of them surfaces here, not in a downstream
+ * consumer.
+ *
+ * Run via Node 22's built-in test runner:
+ *   node --experimental-strip-types --test test/*.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { canonicalizeJSON, canonicalizeJSONBytes } from '../src/canonical.ts';
+import {
+  generateKeyPair,
+  signPayload,
+  verifySignedPayload,
+  signBytes,
+  verifyBytes,
+  codec,
+} from '../src/ed25519.ts';
+import {
+  toAxiomDID,
+  toWebDID,
+  translateDID,
+  isAxiomRooted,
+  didId,
+  AXIOM_AUTHORITY,
+} from '../src/did.ts';
+import { createPiClaim, verifyPiClaim, bootstrapPiClaim } from '../src/pi.ts';
+
+// ── canonical (JCS) ─────────────────────────────────────────────────────────
+
+test('canonicalizeJSON sorts object keys lexicographically', () => {
+  assert.strictEqual(canonicalizeJSON({ b: 2, a: 1 }), '{"a":1,"b":2}');
+});
+
+test('canonicalizeJSON emits valid UTF-16 surrogate pairs verbatim', () => {
+  assert.strictEqual(canonicalizeJSON({ x: '😀' }), '{"x":"😀"}');
+});
+
+test('canonicalizeJSON throws on lone high surrogate', () => {
+  assert.throws(() => canonicalizeJSON({ x: '\uD800' }), /lone high surrogate/);
+});
+
+test('canonicalizeJSON throws on circular structure', () => {
+  const a: Record<string, unknown> = {};
+  a.self = a;
+  assert.throws(() => canonicalizeJSON(a), /circular/);
+});
+
+test('canonicalizeJSON drops undefined-valued keys (RFC 8785)', () => {
+  assert.strictEqual(canonicalizeJSON({ a: 1, b: undefined }), '{"a":1}');
+});
+
+test('canonicalizeJSON throws on non-finite numbers', () => {
+  assert.throws(() => canonicalizeJSON({ x: NaN }), /non-finite/);
+  assert.throws(() => canonicalizeJSON({ x: Infinity }), /non-finite/);
+});
+
+test('canonicalizeJSONBytes returns UTF-8 bytes of canonical string', () => {
+  const bytes = canonicalizeJSONBytes({ hello: 'world' });
+  assert.strictEqual(new TextDecoder().decode(bytes), '{"hello":"world"}');
+});
+
+// ── ed25519 ──────────────────────────────────────────────────────────────────
+
+test('generateKeyPair returns 32-byte keys', () => {
+  const kp = generateKeyPair();
+  assert.strictEqual(kp.privateKey.length, 32);
+  assert.strictEqual(kp.publicKey.length, 32);
+});
+
+test('signPayload + verifySignedPayload round-trip', () => {
+  const kp = generateKeyPair();
+  const signed = signPayload({ msg: 'hello', n: 7 }, kp.privateKey);
+  assert.strictEqual(signed.signature.algorithm, 'Ed25519');
+  assert.strictEqual(signed.signature.canonicalization, 'JCS');
+  assert.strictEqual(signed.publicKey.algorithm, 'Ed25519');
+  assert.strictEqual(signed.publicKey.encoding, 'base64url');
+  assert.match(signed.payload_hash, /^[0-9a-f]{64}$/);
+  assert.ok(verifySignedPayload(signed));
+});
+
+test('verifySignedPayload rejects payload tampering', () => {
+  const kp = generateKeyPair();
+  const signed = signPayload({ amount: 10 }, kp.privateKey);
+  const tampered = { ...signed, payload: { amount: 9999 } };
+  assert.ok(!verifySignedPayload(tampered));
+});
+
+test('verifySignedPayload rejects signature tampering', () => {
+  const kp = generateKeyPair();
+  const signed = signPayload({ ok: true }, kp.privateKey);
+  // Flip one bit in the base64url signature value.
+  const v = signed.signature.value;
+  const flipped = v.replace(/.$/, (c) => (c === 'A' ? 'B' : 'A'));
+  assert.ok(!verifySignedPayload({ ...signed, signature: { ...signed.signature, value: flipped } }));
+});
+
+test('signBytes / verifyBytes round-trip', () => {
+  const kp = generateKeyPair();
+  const msg = new TextEncoder().encode('hello bytes');
+  const sig = signBytes(msg, kp.privateKey);
+  assert.ok(verifyBytes(msg, sig, kp.publicKey));
+});
+
+test('codec.bytesToHex / hexToBytes round-trip', () => {
+  const bytes = new Uint8Array([0x00, 0x7f, 0xff]);
+  assert.strictEqual(codec.bytesToHex(bytes), '007fff');
+  const back = codec.hexToBytes('007fff');
+  assert.deepStrictEqual(Array.from(back), [0x00, 0x7f, 0xff]);
+});
+
+test('codec.bytesToBase64Url / base64UrlToBytes round-trip', () => {
+  const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+  const b64 = codec.bytesToBase64Url(bytes);
+  const back = codec.base64UrlToBytes(b64);
+  assert.deepStrictEqual(Array.from(back), [1, 2, 3, 4, 5]);
+});
+
+// ── did translator ───────────────────────────────────────────────────────────
+
+test('AXIOM_AUTHORITY re-export matches the locked const', () => {
+  assert.strictEqual(AXIOM_AUTHORITY, 'axiomid.app');
+});
+
+test('toAxiomDID produces did:axiom:axiomid.app:<id>', () => {
+  assert.strictEqual(
+    toAxiomDID('iqra-sovereign'),
+    'did:axiom:axiomid.app:iqra-sovereign',
+  );
+});
+
+test('toWebDID produces did:web:axiomid.app:<id>', () => {
+  assert.strictEqual(
+    toWebDID('iqra-sovereign'),
+    'did:web:axiomid.app:iqra-sovereign',
+  );
+});
+
+test('translateDID is lossless across forms', () => {
+  const axiom = toAxiomDID('agent-42');
+  const out = translateDID(axiom);
+  assert.strictEqual(out.id, 'agent-42');
+  assert.strictEqual(out.axiom, axiom);
+  assert.strictEqual(out.web, 'did:web:axiomid.app:agent-42');
+});
+
+test('translateDID rejects unsupported method', () => {
+  assert.throws(() => translateDID('did:evil:axiomid.app:x'), /Unsupported DID/);
+});
+
+test('translateDID rejects illegal id chars', () => {
+  assert.throws(() => translateDID('did:axiom:axiomid.app:has space'), /illegal characters/);
+});
+
+test('isAxiomRooted recognises both forms', () => {
+  assert.ok(isAxiomRooted('did:axiom:axiomid.app:a'));
+  assert.ok(isAxiomRooted('did:web:axiomid.app:a'));
+  assert.ok(!isAxiomRooted('did:web:example.com:a'));
+});
+
+test('didId extracts the bare id', () => {
+  assert.strictEqual(didId('did:axiom:axiomid.app:my-agent'), 'my-agent');
+  assert.strictEqual(didId('did:web:axiomid.app:my-agent'), 'my-agent');
+});
+
+// ── pi network claim ─────────────────────────────────────────────────────────
+
+test('createPiClaim + verifyPiClaim round-trip', () => {
+  const kp = generateKeyPair();
+  const claim = createPiClaim({
+    owner_id: 'iqra-sovereign',
+    app_id: 'pi-app-xxxx',
+    environment: 'production',
+    privateKey: kp.privateKey,
+  });
+  assert.strictEqual(claim.payload.domain, 'axiomid.app');
+  assert.strictEqual(claim.payload.owner_did, 'did:axiom:axiomid.app:iqra-sovereign');
+  assert.strictEqual(claim.well_known_url, 'https://axiomid.app/.well-known/pi-claim.json');
+  const v = verifyPiClaim(claim);
+  assert.strictEqual(v.ok, true);
+});
+
+test('verifyPiClaim rejects DID/domain mismatch', () => {
+  const kp = generateKeyPair();
+  const claim = createPiClaim({
+    owner_id: 'agent-x',
+    app_id: 'pi-app',
+    environment: 'sandbox',
+    privateKey: kp.privateKey,
+  });
+  // Tamper: swap the domain to a different one. Signature still verifies
+  // but the strict DID-domain anchor must reject.
+  const tampered = { ...claim, payload: { ...claim.payload, domain: 'attacker.example' } };
+  // Re-sign so signature verification doesn't fail first.
+  const reSigned = signPayload(tampered.payload, kp.privateKey);
+  const tamperedArtifact = { ...reSigned, well_known_url: claim.well_known_url };
+  const v = verifyPiClaim(tamperedArtifact);
+  assert.strictEqual(v.ok, false);
+  if (!v.ok) assert.strictEqual(v.reason, 'DID_DOMAIN_MISMATCH');
+});
+
+test('verifyPiClaim rejects host-mismatched well_known_url', () => {
+  const kp = generateKeyPair();
+  const claim = createPiClaim({
+    owner_id: 'agent-y',
+    app_id: 'pi-app',
+    environment: 'sandbox',
+    privateKey: kp.privateKey,
+  });
+  const tampered = {
+    ...claim,
+    well_known_url: 'https://attacker.example/.well-known/pi-claim.json',
+  };
+  const v = verifyPiClaim(tampered);
+  assert.strictEqual(v.ok, false);
+});
+
+test('bootstrapPiClaim produces a self-verifying artifact', () => {
+  const { artifact } = bootstrapPiClaim({
+    owner_id: 'fresh-agent',
+    app_id: 'pi-app',
+    environment: 'production',
+  });
+  assert.strictEqual(verifyPiClaim(artifact).ok, true);
+});

--- a/packages/axiom-schema/test/smoke.test.ts
+++ b/packages/axiom-schema/test/smoke.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for @axiom/schema.
+ *
+ * These assertions are intentionally cheap and load-bearing:
+ *   - The version constants match the package.json line, the JSON
+ *     schema $id, and AXIOM.md's quoted pins.
+ *   - The DID type guards match what the schema regex actually
+ *     accepts (no false positives, no false negatives).
+ *   - The shipped schema parses as JSON and carries the locked-const
+ *     `authority` field that the rest of the stack relies on.
+ *
+ * Run via Node 22's built-in test runner:
+ *   node --experimental-strip-types --test test/*.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AIX_FORMAT_VERSION,
+  AIX_PROTOCOL_VERSION,
+  AXIOM_AUTHORITY,
+  AXIOM_PROTOCOL,
+  AIX_SCHEMA_URL,
+  isAxiomDID,
+  isDID,
+} from '../src/index.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = resolve(__dirname, '..', 'schemas', 'aix.schema.json');
+const PKG_PATH = resolve(__dirname, '..', 'package.json');
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'));
+const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf-8'));
+
+// ── version pins ─────────────────────────────────────────────────────────────
+
+test('AIX_FORMAT_VERSION is a major.minor string', () => {
+  assert.match(AIX_FORMAT_VERSION, /^\d+\.\d+$/);
+});
+
+test('AIX_PROTOCOL_VERSION is full semver', () => {
+  assert.match(AIX_PROTOCOL_VERSION, /^\d+\.\d+\.\d+/);
+});
+
+test('package.json#version starts with AIX_FORMAT_VERSION', () => {
+  assert.ok(
+    pkg.version.startsWith(AIX_FORMAT_VERSION),
+    `package.json#version (${pkg.version}) must start with AIX_FORMAT_VERSION (${AIX_FORMAT_VERSION})`,
+  );
+});
+
+test('AXIOM_PROTOCOL identifier is axiom-a2a-v1', () => {
+  assert.strictEqual(AXIOM_PROTOCOL, 'axiom-a2a-v1');
+});
+
+// ── authority lock ───────────────────────────────────────────────────────────
+
+test('AXIOM_AUTHORITY is the locked-const "axiomid.app"', () => {
+  assert.strictEqual(AXIOM_AUTHORITY, 'axiomid.app');
+});
+
+test('schema locks identity_layer.authority to AXIOM_AUTHORITY', () => {
+  const auth = schema.properties.identity_layer.properties.authority;
+  assert.strictEqual(
+    auth.const,
+    AXIOM_AUTHORITY,
+    'schema identity_layer.authority.const must equal AXIOM_AUTHORITY constant',
+  );
+});
+
+// ── schema URL ───────────────────────────────────────────────────────────────
+
+test('AIX_SCHEMA_URL points at the canonical $id', () => {
+  assert.strictEqual(schema.$id, AIX_SCHEMA_URL);
+});
+
+// ── DID type guards ──────────────────────────────────────────────────────────
+
+test('isAxiomDID accepts a well-formed did:axiom', () => {
+  assert.ok(isAxiomDID('did:axiom:axiomid.app:iqra-sovereign'));
+});
+
+test('isAxiomDID rejects did:web (wrong method)', () => {
+  assert.ok(!isAxiomDID('did:web:axiomid.app:iqra-sovereign'));
+});
+
+test('isAxiomDID rejects empty id segment', () => {
+  assert.ok(!isAxiomDID('did:axiom:axiomid.app:'));
+});
+
+test('isAxiomDID rejects non-string', () => {
+  assert.ok(!isAxiomDID(undefined));
+  assert.ok(!isAxiomDID(null));
+  assert.ok(!isAxiomDID(42));
+});
+
+test('isDID accepts did:web', () => {
+  assert.ok(isDID('did:web:example.com:foo'));
+});
+
+test('isDID accepts did:pi', () => {
+  assert.ok(isDID('did:pi:abc123'));
+});
+
+test('isDID rejects malformed strings', () => {
+  assert.ok(!isDID('axiom:axiomid.app:foo'));
+  assert.ok(!isDID('did::missing-method:foo'));
+  assert.ok(!isDID(''));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.19.39
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.4.5
         version: 5.9.3


### PR DESCRIPTION
Turns the canonical core (`@axiom/schema` + `@axiom/identity`) from a pile of merged commits into a machine-verifiable contract. Every PR that touches either package must now satisfy four independent CI gates plus an existing schema-drift ratchet, and a one-page `MIGRATION.md` tells downstream consumers exactly how to switch.

## How it works

The new `.github/workflows/core-ci.yml` runs four jobs scoped by path filter to the canonical-core packages and the lockfile:

1. **Lint** dogfoods `packages/axiom-lint` against the canonical sources, so an `axiom-lint` regression cannot ship by drifting itself first.
2. **Typecheck** runs `tsc --noEmit` per package via a matrix with `fail-fast: false`, so a break in `@axiom/schema` does not mask a break in `@axiom/identity`.
3. **Unit smoke** runs the Node 22 built-in test runner over the per-package `test/*.test.ts` files. Coverage is intentionally narrow but load-bearing: JCS edge cases (surrogate validation, NaN rejection, circular guard), Ed25519 round-trip with payload AND signature tamper detection, DID translator round-trip with illegal-char rejection, and the Pi claim happy path plus the `DID_DOMAIN_MISMATCH` / URL host mismatch rejections.
4. **Cross-package contract** runs `packages/axiom-identity/test/contract.test.ts`, which imports from both packages and reads `schemas/aix.schema.json`. The suite fails if `AXIOM_AUTHORITY` ever drifts between the two packages, if `schema.properties.identity_layer.properties.authority.const` drifts from that value, if identity-emitted DIDs fail the schema-shipped `isAxiomDID` / `isDID` guards, or if the signed-payload algorithm or encoding enums fall outside the schema's `$defs.Signature` / `$defs.PublicKey` enums. This is the anti-drift mechanism the RFC promised.

Test runner choice: the packages publish ESM with `.js` import specifiers (the form Node ESM consumers see at runtime against the built `dist/`), but CI runs against in-tree `src/*.ts` via `node --import tsx --test`. The `tsx` loader maps `.js` back to `.ts` during the test pass, so the same source files satisfy both views. `tsx` is added to `packages/axiom-identity/devDependencies` (already present in `@axiom/schema`) and `pnpm-lock.yaml` is regenerated so `--frozen-lockfile` continues to install cleanly.

`MIGRATION.md` is one page, four sections: what changed, who is affected, how to migrate (with import-diff blocks for types/version pins, identity primitives, signing round-trip, Pi claim), and what CI guarantees. The Pi-claim section explicitly calls out the boolean → tagged-result shape change, because that is the only non-obvious API shift in the migration.

This PR adds workflows + tests + docs only; no canonical-core source file is modified. The existing `axiom-schema-codegen.yml` (schema ↔ generated types drift check) remains in force and is referenced from both `core-ci.yml` and `MIGRATION.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->