### PR TITLE
chore(deps): enable Dependabot for weekly automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot configuration for aix-format (L1 Protocol).
+#
+# Self-evolving stack: weekly automated PRs for security and minor/patch
+# version bumps across every ecosystem this repo touches. Per AIX Sovereign
+# Stack quick-win-#2 (proactive maintenance): we pull dependency updates
+# rather than wait for a CVE to bite us.
+#
+# Conventions:
+#   - All update PRs land Mondays UTC.
+#   - Minor+patch updates are grouped per ecosystem so review noise stays
+#     low (one PR per ecosystem per week instead of fifteen).
+#   - Major updates are opt-in: dependabot opens them as separate PRs so
+#     they go through human review explicitly.
+#   - PRs target `main` and use commit-message-prefix that matches the
+#     stack's Conventional Commits convention.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - "dependencies"
+      - "automated"
+    groups:
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
Quick Win #2 from the AIX Sovereign Stack self-evolving-repo roadmap. Enables Dependabot on this repo so security and minor/patch version bumps land as automated PRs every Monday at 06:00 UTC instead of waiting for a CVE to bite us. Updates are grouped per ecosystem (one PR per ecosystem per week for minor+patch) and emit Conventional Commit prefixes matching the stack convention (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`).

## How it works

This config covers npm at the repo root (workspaces + dev dependencies) and `github-actions` for workflow pins. Minor and patch updates are grouped by `dependency-type` so production deps and dev deps each become a single weekly PR rather than fifteen noisy ones; major bumps still open as separate PRs so they go through explicit human review. The label set (`dependencies`, `automated`, `ci`) keeps the project board organized, and the 06:00 UTC Monday window batches noise into a single review session at the start of the week.

Safety: zero runtime impact. Dependabot does not auto-merge anything; this PR only adds the configuration file. Operators retain full control over which dependency PRs land. Out of scope: pnpm-workspace-specific grouping (Dependabot v2 supports it natively now, but the default per-package grouping is fine for this stack's size).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->