### PR TITLE
fix(tests): use Node 18 compatible dirname resolution in e2e suites

### DIFF
--- a/tests/e2e/convert-cli.test.js
+++ b/tests/e2e/convert-cli.test.js
@@ -11,9 +11,13 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 
-const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+// import.meta.dirname is Node 20.11+, but package.json declares engines.node
+// >=18.0.0. Derive the dirname via fileURLToPath for Node 18 compatibility.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const CONVERT = path.join(REPO_ROOT, 'bin', 'aix-convert.js');
 
 function runConvert(args) {

--- a/tests/e2e/full-lifecycle.test.js
+++ b/tests/e2e/full-lifecycle.test.js
@@ -19,10 +19,14 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import crypto from 'crypto';
 import { execFileSync } from 'child_process';
 
-const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+// import.meta.dirname is Node 20.11+, but package.json declares engines.node
+// >=18.0.0. Derive the dirname via fileURLToPath for Node 18 compatibility.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const SIGN = path.join(REPO_ROOT, 'scripts', 'agent-sign.js');
 const VERIFY = path.join(REPO_ROOT, 'scripts', 'agent-verify.js');
 

--- a/tests/e2e/plugins-cli.test.js
+++ b/tests/e2e/plugins-cli.test.js
@@ -11,9 +11,13 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 
-const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+// import.meta.dirname is Node 20.11+, but package.json declares engines.node
+// >=18.0.0. Derive the dirname via fileURLToPath for Node 18 compatibility.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const PLUGINS = path.join(REPO_ROOT, 'bin', 'aix-plugins.js');
 
 function makeWorkspace() {

--- a/tests/e2e/validate-cli.test.js
+++ b/tests/e2e/validate-cli.test.js
@@ -11,9 +11,13 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 
-const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+// import.meta.dirname is Node 20.11+, but package.json declares engines.node
+// >=18.0.0. Derive the dirname via fileURLToPath for Node 18 compatibility.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const VALIDATE = path.join(REPO_ROOT, 'bin', 'aix-validate.js');
 
 function runValidate(args, opts = {}) {


### PR DESCRIPTION
CodeRabbit flagged on PR #178 that the four new e2e suites used `import.meta.dirname`, which is only available from Node 20.11 onwards. The package declares `engines.node >=18.0.0`, so the suites would have broken on the minimum supported runtime. PR #178 was merged before the fix could land, so this is a follow-up against main.

How it works:
- Replace `import.meta.dirname` with `fileURLToPath(import.meta.url) + path.dirname`, the standard Node 18 compatible pattern, in all four e2e suites: `validate-cli.test.js`, `convert-cli.test.js`, `plugins-cli.test.js`, and `full-lifecycle.test.js`.
- The new resolver computes `REPO_ROOT` exactly the same way as before; only the API used to derive `__dirname` changes, so test behaviour is identical on Node 20+ and now also works on Node 18.

Net change: 4 files, 20 insertions, 4 deletions. No behavioural change on currently supported runtimes; the suites now also run cleanly on the declared minimum Node version.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test infrastructure across four test suites (convert CLI, full-lifecycle, plugins CLI, and validate CLI) to enhance Node.js version compatibility. Improved path resolution handling to ensure tests execute reliably across supported Node.js versions, broadening the range of environments where the test suite can run effectively.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moeabdelaziz007/aix-format/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->