### PR TITLE
fix(vitest): exclude nested node_modules from test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,9 +10,12 @@ export default defineConfig({
     // The tests/e2e/ folder is excluded here because those tests use
     // node:test and are run by the dedicated test:e2e:node script.
     include: ['tests/**/*.test.{js,ts}', 'packages/**/*.test.{js,ts}'],
+    // Use **/node_modules/** to also catch transitively-installed test files
+    // that ship inside dependency packages (zod ships its own tests, etc.).
+    // The plain 'node_modules/**' pattern only matches the top-level dir.
     exclude: [
-      'node_modules/**',
-      'dist/**',
+      '**/node_modules/**',
+      '**/dist/**',
       'apps/studio/.next/**',
       'tests/e2e/**',
     ],
@@ -28,8 +31,8 @@ export default defineConfig({
         'apps/*/src/**/*.{js,ts}',
       ],
       exclude: [
-        'node_modules/**',
-        'dist/**',
+        '**/node_modules/**',
+        '**/dist/**',
         'apps/studio/.next/**',
         '**/*.d.ts',
         '**/*.gen.ts',


### PR DESCRIPTION
While running the vitest suite locally to verify what PR #178 actually activated, I noticed the runner was pulling in test files from transitively-installed dependencies (zod ships its own test suites inside `packages/*/node_modules/zod/...`). The `node_modules/**` exclude pattern only matches the top-level `node_modules/` directory, so every package with its own `node_modules/` was leaking vendor tests into the run.

How it works:
- Switch `test.exclude` from `node_modules/**` to `**/node_modules/**` so transitively nested test files are excluded at any depth.
- Apply the same `**/node_modules/**` pattern to `coverage.exclude` for consistency.
- Also bump `dist/**` to `**/dist/**` so package-local `dist/` folders are excluded as well.

No behavioural change for repo-owned tests, just removes the noise from vendor packages. The test-file count drops from 756 to 53 (vendor tests no longer count); pass/fail rates on repo-owned tests are unchanged.

While I was there I noticed a much larger pre-existing issue worth flagging separately: `pnpm test` is **not** invoked by any CI workflow (CI only runs `node --test packages/axiom-*/test/*.test.ts` per package in `axiom-checks.yml`). The vitest suite has been silently broken on `main` for a while: 43 of 49 test files were already failing before PR #178, and many `tests/*.test.js` files are actually `node:test`-style scripts or standalone scripts using `process.exit()` that were never vitest-compatible. Surfacing and fixing that broader breakage is a separate, larger workstream and not in scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->