### PR TITLE
fix(aix-convert): await async parseFile so meta.name resolves

### DIFF
--- a/bin/aix-convert.js
+++ b/bin/aix-convert.js
@@ -89,7 +89,11 @@ const parser = new AIXParser();
 
 try {
   console.log(`📖 Reading ${inputPath}...`);
-  const agent = parser.parseFile(resolvedInput);
+  // parser.parseFile is async; without await, `agent` is a Promise
+  // and agent.meta.name resolves to undefined, which used to throw
+  // "Cannot read properties of undefined (reading 'name')" on every
+  // conversion. ESM at this Node version supports top-level await.
+  const agent = await parser.parseFile(resolvedInput);
   
   console.log(`✅ Parsed successfully`);
   console.log(`   Agent: ${agent.meta.name}`);


### PR DESCRIPTION
`bin/aix-convert.js` called `parser.parseFile()` without awaiting it. Since `parser.parseFile` is declared `async` (`core/parser.js:51`), the returned value was a Promise and the next line's `agent.meta.name` resolved to `undefined`, so every conversion blew up with `Cannot read properties of undefined (reading 'name')`. This blocked the previously-skipped `'yaml -> json'` test in `tests/e2e/convert-cli.test.js`.

How it works:
- Add `await` to the `parser.parseFile(resolvedInput)` call. The file is an ESM module and the package's `engines.node` is `>=18`, so top-level `await` is supported.
- Add an inline comment explaining the gotcha so the next person doesn't strip the `await` thinking it's redundant.
- No changes to argument parsing, format conversion, checksum recalculation, or output writing. The conversion path simply now sees a real `AIXAgent` object instead of a pending Promise.

Verified by running `node bin/aix-convert.js examples/persona-agent.aix /tmp/out.json --format json` (succeeds, writes valid JSON with all expected sections and a recalculated checksum) and `node --test tests/e2e/convert-cli.test.js` (4/4 pass, including the conversion roundtrip case that was failing).

Same missing-`await` pattern exists in `scripts/abom-check.js:40` and `tests/integration/parser.integration.test.ts:16`; those are tracked separately as part of the broader vitest cleanup track.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->