### PR TITLE
fix(aix-plugins): drop missing commander dep, use Node stdlib

### DIFF
--- a/bin/aix-plugins.js
+++ b/bin/aix-plugins.js
@@ -1,9 +1,38 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import { readFile, writeFile } from 'fs/promises';
+/**
+ * AIX Plugins CLI
+ *
+ * Manage the local .aix-plugins.json registry. Subcommands:
+ *   list                    - List installed plugins.
+ *   add <path>              - Add a plugin (flags: --priority N, --disabled).
+ *   remove <path>           - Remove a plugin.
+ *   enable <path>           - Mark a plugin enabled.
+ *   disable <path>          - Mark a plugin disabled.
+ *   help                    - Print this help.
+ *
+ * Previously used 'commander' which was never added as a dependency,
+ * so the CLI threw ERR_MODULE_NOT_FOUND on every invocation. Rewritten
+ * with the Node stdlib so it has zero runtime deps.
+ */
 
-const program = new Command();
+import { readFile, writeFile } from 'node:fs/promises';
+
 const CONFIG_PATH = '.aix-plugins.json';
+
+const HELP = `aix-plugins - Manage AIX validation plugins
+
+Usage:
+  aix-plugins <command> [args] [flags]
+
+Commands:
+  list                          List installed plugins
+  add <path> [--priority N] [--disabled]
+                                Register a plugin
+  remove <path>                 Remove a plugin
+  enable <path>                 Enable a plugin
+  disable <path>                Disable a plugin
+  help, --help, -h              Show this help
+`;
 
 async function loadConfig() {
   try {
@@ -17,9 +46,26 @@ async function saveConfig(config) {
   await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
-program.name('aix-plugins').description('Manage AIX validation plugins').version('1.0.0');
+/**
+ * Pull a flag value out of argv. Returns the value string, or null if
+ * the flag was not provided. Supports both `--flag value` and
+ * `--flag=value` styles.
+ */
+function flagValue(argv, name) {
+  const idx = argv.indexOf(`--${name}`);
+  if (idx !== -1 && argv[idx + 1] !== undefined && !argv[idx + 1].startsWith('--')) {
+    return argv[idx + 1];
+  }
+  const eq = argv.find((a) => a.startsWith(`--${name}=`));
+  if (eq) return eq.slice(name.length + 3);
+  return null;
+}
 
-program.command('list').description('List installed plugins').action(async () => {
+function hasFlag(argv, name) {
+  return argv.includes(`--${name}`);
+}
+
+async function cmdList() {
   const config = await loadConfig();
   console.log('Installed plugins:');
   for (const [path, options] of Object.entries(config.plugins || {})) {
@@ -27,50 +73,91 @@ program.command('list').description('List installed plugins').action(async () =>
     const priority = options.priority !== undefined ? ` (priority: ${options.priority})` : '';
     console.log(`${status} ${path}${priority}`);
   }
-});
+}
 
-program.command('add <path>').description('Add a plugin')
-  .option('-p, --priority <number>', 'Plugin priority', parseInt)
-  .option('--disabled', 'Add but keep disabled')
-  .action(async (path, options) => {
-    const config = await loadConfig();
-    config.plugins[path] = {
-      enabled: !options.disabled,
-      ...(options.priority !== undefined && { priority: options.priority })
-    };
-    await saveConfig(config);
-    console.log(`✅ Added plugin: ${path}`);
-  });
+async function cmdAdd(argv) {
+  const path = argv[0];
+  if (!path) {
+    console.error('❌ Error: aix-plugins add <path>');
+    process.exit(1);
+  }
+  const priorityRaw = flagValue(argv, 'priority');
+  const priority = priorityRaw !== null ? Number.parseInt(priorityRaw, 10) : undefined;
+  const disabled = hasFlag(argv, 'disabled');
 
-program.command('remove <path>').description('Remove a plugin').action(async (path) => {
   const config = await loadConfig();
-  delete config.plugins[path];
+  config.plugins ??= {};
+  config.plugins[path] = {
+    enabled: !disabled,
+    ...(priority !== undefined && !Number.isNaN(priority) && { priority }),
+  };
+  await saveConfig(config);
+  console.log(`✅ Added plugin: ${path}`);
+}
+
+async function cmdRemove(argv) {
+  const path = argv[0];
+  if (!path) {
+    console.error('❌ Error: aix-plugins remove <path>');
+    process.exit(1);
+  }
+  const config = await loadConfig();
+  delete config.plugins?.[path];
   await saveConfig(config);
   console.log(`🗑️  Removed plugin: ${path}`);
-});
+}
 
-program.command('enable <path>').description('Enable a plugin').action(async (path) => {
+async function cmdSetEnabled(argv, enabled) {
+  const path = argv[0];
+  if (!path) {
+    console.error('❌ Error: aix-plugins enable|disable <path>');
+    process.exit(1);
+  }
   const config = await loadConfig();
-  if (config.plugins[path]) {
-    config.plugins[path].enabled = true;
+  if (config.plugins?.[path]) {
+    config.plugins[path].enabled = enabled;
     await saveConfig(config);
-    console.log(`✅ Enabled plugin: ${path}`);
+    console.log(`${enabled ? '✅ Enabled' : '❌ Disabled'} plugin: ${path}`);
   } else {
     console.error(`❌ Plugin not found: ${path}`);
+    process.exit(1);
   }
-});
+}
 
-program.command('disable <path>').description('Disable a plugin').action(async (path) => {
-  const config = await loadConfig();
-  if (config.plugins[path]) {
-    config.plugins[path].enabled = false;
-    await saveConfig(config);
-    console.log(`❌ Disabled plugin: ${path}`);
-  } else {
-    console.error(`❌ Plugin not found: ${path}`);
+async function main() {
+  const [, , command, ...rest] = process.argv;
+
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    console.log(HELP);
+    return;
   }
-});
 
-program.parse();
+  switch (command) {
+    case 'list':
+      await cmdList();
+      break;
+    case 'add':
+      await cmdAdd(rest);
+      break;
+    case 'remove':
+      await cmdRemove(rest);
+      break;
+    case 'enable':
+      await cmdSetEnabled(rest, true);
+      break;
+    case 'disable':
+      await cmdSetEnabled(rest, false);
+      break;
+    default:
+      console.error(`❌ Unknown command: ${command}\n`);
+      console.log(HELP);
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`❌ Error: ${err.message}`);
+  process.exit(1);
+});
 
 // Made with Moe Abdelaziz


### PR DESCRIPTION
`bin/aix-plugins.js` was importing `commander`, but `commander` is not listed in `package.json` and not installed in `node_modules/`. Every invocation crashed with `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'commander' imported from /home/daytona/aix-format/bin/aix-plugins.js`. That blocked all three `tests/e2e/plugins-cli.test.js` tests from passing.

How it works:
- Rewrite the CLI using plain `process.argv` parsing instead of `commander`, so the bin has zero runtime dependencies. The same dependency-free pattern is already used by the other four bins (`aix-validate`, `aix-convert`, `aix-regulator-export`, `manifest-validate`), so this just makes the surface consistent.
- All five subcommands preserve their behaviour: `list`, `add <path> [--priority N] [--disabled]`, `remove <path>`, `enable <path>`, `disable <path>`.
- Add a proper `--help` / `-h` / `help` path that prints usage and exits 0, and explicit non-zero exit codes on missing args / unknown commands.

Verified manually (`list`, `add`, `disable`, `enable`, `help` all behave correctly in an isolated tempdir) and via `node --test tests/e2e/plugins-cli.test.js` (3/3 pass; was 0/3 before this fix). No `package.json` or lockfile changes needed since the new implementation only depends on `node:fs/promises`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->