### PR TITLE
ci(identity): add @axiom/identity autopublish workflow

### DIFF
--- a/.github/workflows/axiom-identity-publish.yml
+++ b/.github/workflows/axiom-identity-publish.yml
@@ -1,0 +1,85 @@
+name: "@axiom/identity autopublish on tag"
+
+# Publishes @axiom/identity to npm when a tag matching the pattern
+# `axiom-identity-v*` is pushed (e.g. `axiom-identity-v1.3.0`). The tag
+# version MUST match the version field in
+# `packages/axiom-identity/package.json` exactly; the publish step
+# verifies this and fails on mismatch.
+#
+# Mirrors `axiom-schema-publish.yml` minus the codegen step, since
+# @axiom/identity has no schema-driven generator.
+#
+# Required repository secret:
+#   NPM_TOKEN — npm token with publish access to the @axiom scope.
+#
+# Manual smoke-test trigger via `workflow_dispatch` is also available
+# for re-publishing after a token rotation or scope handover.
+
+on:
+  push:
+    tags:
+      - 'axiom-identity-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run npm publish --dry-run only (no actual publish)'
+        required: false
+        default: 'true'
+        type: choice
+        options: ['true', 'false']
+
+permissions:
+  contents: read
+  id-token: write  # for npm provenance attestations
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: npm-publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches package.json#version
+        if: github.event_name == 'push'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#axiom-identity-v}"
+          PKG_VERSION=$(node -p "require('./packages/axiom-identity/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match package.json version '$PKG_VERSION'"
+            exit 1
+          fi
+          echo "✓ Tag $GITHUB_REF_NAME matches package.json#version $PKG_VERSION"
+
+      - name: Build
+        working-directory: packages/axiom-identity
+        run: pnpm run build
+
+      - name: Publish (dry-run on manual trigger by default)
+        working-directory: packages/axiom-identity
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run: skipping actual publish."
+            npm publish --dry-run --access public --provenance
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
Mirrors the existing `axiom-schema-publish.yml` workflow for the sibling `@axiom/identity` package. Triggers on tags matching `axiom-identity-v*` and also supports `workflow_dispatch` with a dry-run option.

## Why

`@axiom/identity` is configured for publication (`publishConfig.access: public`, version `1.3.0`, `files` set, `exports` map complete) but no CI publishes it today. As a direct consequence, every downstream stack member (L2 iqra, L4 AlphaAxiom, L5 PiWorker-OS, L6 GemClaw) currently vendors the identity primitives locally instead of consuming this package. iqra's `src/lib/iqra/14-aix/` holds near-byte-identical copies of `canonical.ts`, `ed25519.ts`, `did.ts`, `pi.ts` (~1,400 LOC of drift surface).

Adding this workflow unblocks the downstream migration to a real npm dependency.

## How it works

Workflow is a near-mirror of `axiom-schema-publish.yml`:

- Same triggers (tag push, workflow_dispatch with dry-run).
- Same Node 22 + pnpm setup.
- Same `NPM_TOKEN` secret, same `npm-publish` environment, same provenance attestation.
- Same tag-vs-`package.json#version` verification step (prefix is `axiom-identity-v`).
- Drops the codegen step because `@axiom/identity` has no schema-driven generator.

## Safety

Diff: one new workflow file, 85 lines. No edits to existing files, no sovereign paths touched. The first real publish requires a maintainer to push a tag (`axiom-identity-v1.3.0`) or invoke the workflow manually with `dry_run=false`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Moeabdelaziz007/codesmith/aix-format/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated publishing workflow for the @axiom/identity package. When a git tag is pushed matching `axiom-identity-v*`, the package automatically publishes to npm with version verification. Supports manual dry-run publishes via workflow dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moeabdelaziz007/aix-format/pull/195)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->