### PR TITLE
chore: unify all @axiom/* packages to v0.1.0

### DIFF
--- a/packages/axiom-autofix/package.json
+++ b/packages/axiom-autofix/package.json
@@ -17,5 +17,9 @@
     "node": ">=22"
   },
   "license": "MIT",
-  "files": ["src", "bin", "README.md"]
+  "files": [
+    "src",
+    "bin",
+    "README.md"
+  ]
 }

--- a/packages/axiom-autofix/tsconfig.json
+++ b/packages/axiom-autofix/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -11,8 +13,15 @@
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": false,
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/axiom-health/package.json
+++ b/packages/axiom-health/package.json
@@ -17,5 +17,9 @@
     "node": ">=22"
   },
   "license": "MIT",
-  "files": ["src", "bin", "README.md"]
+  "files": [
+    "src",
+    "bin",
+    "README.md"
+  ]
 }

--- a/packages/axiom-health/tsconfig.json
+++ b/packages/axiom-health/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -11,8 +13,15 @@
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": false,
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/axiom-identity/package.json
+++ b/packages/axiom-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiom/identity",
-  "version": "1.3.0",
+  "version": "0.1.0",
   "description": "Canonical AIX identity primitives: Axiom DID translator, Ed25519 sign/verify, RFC 8785 JCS canonicalization, and Pi Network domain-claim flow. Edge-safe, no native bindings.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/axiom-lint/package.json
+++ b/packages/axiom-lint/package.json
@@ -17,5 +17,9 @@
     "node": ">=22"
   },
   "license": "MIT",
-  "files": ["src", "bin", "README.md"]
+  "files": [
+    "src",
+    "bin",
+    "README.md"
+  ]
 }

--- a/packages/axiom-lint/tsconfig.json
+++ b/packages/axiom-lint/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -11,8 +13,15 @@
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": false,
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/axiom-pi/package.json
+++ b/packages/axiom-pi/package.json
@@ -18,7 +18,13 @@
     "typescript": "^5.9.3",
     "vitest": "^2.1.8"
   },
-  "keywords": ["pi-network", "kyc", "payment", "axiom", "aix"],
+  "keywords": [
+    "pi-network",
+    "kyc",
+    "payment",
+    "axiom",
+    "aix"
+  ],
   "author": "Mohamed Abdelaziz",
   "license": "Apache-2.0"
 }

--- a/packages/axiom-schema/package.json
+++ b/packages/axiom-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiom/schema",
-  "version": "1.3.0",
+  "version": "0.1.0",
   "description": "Canonical AIX manifest JSON Schema and TypeScript types. Single source of truth for the AIX (Artificial Intelligence eXchange) Sovereign Protocol.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/axiom-validate/package.json
+++ b/packages/axiom-validate/package.json
@@ -21,5 +21,9 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1"
   },
-  "files": ["src", "bin", "README.md"]
+  "files": [
+    "src",
+    "bin",
+    "README.md"
+  ]
 }

--- a/packages/axiom-validate/tsconfig.json
+++ b/packages/axiom-validate/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -11,8 +13,15 @@
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": false,
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- Unified all 7 @axiom/* packages to version **0.1.0**
- Added tsconfig.json to packages missing it (axiom-validate, axiom-lint, axiom-health, axiom-autofix)
- Set `types: ["node"]` for packages requiring Node.js types
- All packages build successfully

### Packages affected
| Package | Old Version | New Version |
|---------|------------|------------|
| @axiom/identity | 1.3.0 | 0.1.0 |
| @axiom/schema | 1.3.0 | 0.1.0 |
| @axiom/pi | 0.1.0 | 0.1.0 |
| @axiom/validate | 0.1.0 | 0.1.0 |
| @axiom/lint | 0.1.0 | 0.1.0 |
| @axiom/health | 0.1.0 | 0.1.0 |
| @axiom/autofix | 0.1.0 | 0.1.0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added TypeScript configuration files for multiple packages with ES2022 targeting and strict type-checking enabled
  * Reformatted package distribution configurations across packages
  * Updated package versions for axiom-identity and axiom-schema from 1.3.0 to 0.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIX-Format/aix-format/pull/207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**Disclaimer This is AxiomID Review Agent.

<h3>Greptile Summary</h3>

This PR attempts to unify all seven `@axiom/*` packages to `v0.1.0` and adds `tsconfig.json` files to four packages that were missing them (`axiom-validate`, `axiom-lint`, `axiom-health`, `axiom-autofix`). Most of the changes are JSON formatting normalisations; the substantive concerns are the version regressions and tsconfig inconsistencies described below.

- `@axiom/identity` and `@axiom/schema` are **downgraded** from `1.3.0` → `0.1.0`, which violates the project's strict SemVer doctrine (`AIX_STACK_VERSIONING.md §3.1`) and will cause `npm publish` to fail if either package was already released at `1.3.0`.
- Four new `tsconfig.json` files set `outDir: ./dist` and `declaration: true`, but the corresponding `package.json` files distribute TypeScript source directly (`main: src/index.ts`) and exclude `dist/` from the `files` array, making the compiled output unreachable.
- `axiom-pi/tsconfig.json` silently drops `resolveJsonModule` and `isolatedModules`, which are defensive guards worth retaining.

<h3>Confidence Score: 3/5</h3>

Do not merge until the version regression for @axiom/identity and @axiom/schema is resolved — a downgrade from 1.3.0 to 0.1.0 would break downstream consumers pinning to ^1.x and would fail npm publish outright if those versions are already live.

The two canonical packages (@axiom/identity and @axiom/schema) are being rolled back by three minor versions. These packages carry publishConfig: { access: "public" } and have dedicated publish workflows, so the regression is likely to surface immediately as a publish failure. Downstream repos that consume them via SemVer ranges would also be silently left behind. The four new tsconfigs and the axiom-pi changes are benign by comparison, but the version issue is substantial enough to block the PR as-is.

packages/axiom-identity/package.json and packages/axiom-schema/package.json require the most attention due to the version regression. packages/axiom-pi/tsconfig.json is worth a second look for the removed compiler flags.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/axiom-identity/package.json | Version downgraded from 1.3.0 to 0.1.0 — violates strict SemVer doctrine and would fail npm publish if already released at 1.3.0 |
| packages/axiom-schema/package.json | Version downgraded from 1.3.0 to 0.1.0 — same SemVer regression as axiom-identity; this is the canonical schema package downstream consumers depend on |
| packages/axiom-pi/tsconfig.json | Adds types: ["node"] and removes resolveJsonModule, isolatedModules, declarationMap, forceConsistentCasingInFileNames — mostly fine but silent removal of resolveJsonModule could break JSON imports |
| packages/axiom-autofix/tsconfig.json | New tsconfig added; outDir/declaration settings are inconsistent with package.json distributing src directly rather than dist |
| packages/axiom-health/tsconfig.json | New tsconfig identical to axiom-autofix; same outDir/declaration inconsistency with source-distributed package |
| packages/axiom-lint/tsconfig.json | New tsconfig identical to axiom-autofix; same outDir/declaration inconsistency with source-distributed package |
| packages/axiom-validate/tsconfig.json | New tsconfig identical to axiom-autofix; same outDir/declaration inconsistency with source-distributed package |
| packages/axiom-autofix/package.json | Formatting-only change: files array expanded to multi-line; no functional change |
| packages/axiom-health/package.json | Formatting-only change: files array expanded to multi-line; no functional change |
| packages/axiom-lint/package.json | Formatting-only change: files array expanded to multi-line; no functional change |
| packages/axiom-validate/package.json | Formatting-only change: files array expanded to multi-line; no functional change |
| packages/axiom-pi/package.json | Formatting-only change: keywords array expanded to multi-line; no functional change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph versions["Version Changes"]
        id_old["@axiom/identity v1.3.0"] -->|"downgraded ⚠️"| id_new["@axiom/identity v0.1.0"]
        sc_old["@axiom/schema v1.3.0"] -->|"downgraded ⚠️"| sc_new["@axiom/schema v0.1.0"]
        pi["@axiom/pi v0.1.0"] -->|"unchanged"| pi2["@axiom/pi v0.1.0"]
        val["@axiom/validate v0.1.0"] -->|"unchanged"| val2["@axiom/validate v0.1.0"]
        lint["@axiom/lint v0.1.0"] -->|"unchanged"| lint2["@axiom/lint v0.1.0"]
        hlth["@axiom/health v0.1.0"] -->|"unchanged"| hlth2["@axiom/health v0.1.0"]
        fix["@axiom/autofix v0.1.0"] -->|"unchanged"| fix2["@axiom/autofix v0.1.0"]
    end
    subgraph tsconfig["New tsconfig.json files"]
        tc1["axiom-validate/tsconfig.json\noutDir: dist ⚠️"]
        tc2["axiom-lint/tsconfig.json\noutDir: dist ⚠️"]
        tc3["axiom-health/tsconfig.json\noutDir: dist ⚠️"]
        tc4["axiom-autofix/tsconfig.json\noutDir: dist ⚠️"]
    end
    subgraph distribute["Distribution (unchanged)"]
        src["main: src/index.ts\nfiles: src, bin, README"]
    end
    tc1 & tc2 & tc3 & tc4 -->|"tsc outputs to"| dist["dist/ — not published"]
    src -.->|"actually used by consumers"| src
```

<a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aix-format%2Faix-format%22%20on%20the%20existing%20branch%20%22chore%2Funify-axiom-packages-v0.1.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Funify-axiom-packages-v0.1.0%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Faxiom-identity%2Fpackage.json%3A3%0A**Version%20regression%20violates%20project%20SemVer%20doctrine**%0A%0A%60%40axiom%2Fidentity%60%20is%20being%20downgraded%20from%20%601.3.0%60%20%E2%86%92%20%600.1.0%60.%20%60AIX_STACK_VERSIONING.md%20%C2%A73.1%60%20binds%20this%20repo%20to%20strict%20SemVer%202.0.0%20and%20states%20%22a%20consumer%20running%20%60npm%20install%60%20MUST%20get%20an%20answer%20that%20reflects%20reality.%22%20A%20rollback%20destroys%20the%20semantic%20record%20of%20three%20minor-version%20cycles%20of%20work.%20More%20critically%2C%20if%20this%20package%20has%20already%20been%20published%20to%20npm%20at%20%601.3.0%60%2C%20the%20registry%20will%20reject%20a%20re-publish%20at%20%600.1.0%60%20%28%60You%20cannot%20publish%20over%20the%20previously%20published%20versions%60%29%2C%20and%20any%20downstream%20consumer%20pinning%20%60%5E1.0.0%60%20or%20%60%5E1.3.0%60%20will%20not%20pick%20up%20the%20update.%20The%20same%20applies%20to%20%60%40axiom%2Fschema%60%20in%20%60packages%2Faxiom-schema%2Fpackage.json%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Faxiom-autofix%2Ftsconfig.json%3A7-8%0A**%60outDir%60%2F%60declaration%60%20settings%20are%20inconsistent%20with%20how%20this%20package%20is%20distributed**%0A%0A%60%40axiom%2Fautofix%60%20%28and%20identically%20%60%40axiom%2Fvalidate%60%2C%20%60%40axiom%2Flint%60%2C%20%60%40axiom%2Fhealth%60%29%20ships%20TypeScript%20source%20directly%3A%20%60%22main%22%3A%20%22src%2Findex.ts%22%60%2C%20%60%22exports%22%3A%20%7B%20%22.%22%3A%20%22.%2Fsrc%2Findex.ts%22%20%7D%60%2C%20and%20%60%22files%22%60%20contains%20only%20%60src%60%2C%20%60bin%60%2C%20and%20%60README.md%60.%20The%20new%20tsconfig%20sets%20%60outDir%3A%20.%2Fdist%60%20and%20%60declaration%3A%20true%60%2C%20but%20%60dist%2F%60%20is%20never%20referenced%20by%20%60package.json%60%20and%20is%20not%20in%20the%20%60files%60%20array%2C%20so%20the%20compiled%20output%20is%20never%20published.%20Consider%20either%20removing%20%60outDir%60%2F%60declaration%60%20from%20these%20tsconfigs%20or%20aligning%20the%20%60package.json%60%20%60main%60%2C%20%60exports%60%2C%20and%20%60files%60%20fields%20to%20point%20at%20%60dist%2F%60.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Faxiom-pi%2Ftsconfig.json%3A10-14%0A**%60resolveJsonModule%60%20and%20%60isolatedModules%60%20silently%20removed**%0A%0ATwo%20options%20that%20were%20deliberately%20set%20in%20the%20previous%20config%20are%20dropped%3A%20%60resolveJsonModule%60%20%28required%20to%20import%20%60.json%60%20files%29%20and%20%60isolatedModules%60%20%28ensures%20each%20file%20is%20independently%20transpile-safe%29.%20Although%20no%20JSON%20imports%20exist%20today%2C%20removing%20%60resolveJsonModule%60%20will%20silently%20break%20any%20future%20JSON%20import%20in%20this%20package.%20%60isolatedModules%60%20is%20also%20a%20good%20defensive%20guard%20for%20transpile-only%20tooling%3B%20its%20removal%20is%20a%20quiet%20footgun.%0A%0A&repo=aix-format%2Faix-format"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: unify all @axiom/\* packages to v0..."](https://github.com/aix-format/aix-format/commit/957f8544ce0a0c41bfe8ebf088ae91a5fc656733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32278617)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->